### PR TITLE
fix(login): propagar host real de escuta do CLI ao web app via parâmetro host

### DIFF
--- a/docs/specs/DESIGN.md
+++ b/docs/specs/DESIGN.md
@@ -1,170 +1,324 @@
-# Design Técnico — Issue #5: Falha no Job de Release (release-please)
+# Design Técnico — Issue #17: Erro no login do CLI via OAuth
 
 ## 1. Contexto e Estado Atual
 
 ### 1.1 Problema
 
-O workflow `Release Please` (`.github/workflows/release-please.yml`) falha com o erro:
+O comando `aitk login` inicia um servidor HTTP temporário local e abre o browser para autenticação OAuth via web app. O web app, ao construir a URL de callback para o CLI, usa sempre `http://localhost:PORT/callback`. Essa suposição falha em sistemas onde `localhost` resolve para um endereço IP diferente do que o servidor CLI está escutando:
 
+- **Caso A**: Servidor CLI escuta em `::` (IPv6 dual-stack) → browser resolve `localhost` como `127.0.0.1` (IPv4) → conexão recusada
+- **Caso B**: Servidor CLI fez fallback para `127.0.0.1` (IPv4) → browser resolve `localhost` como `::1` (IPv6) → conexão recusada
+- **Caso C**: Browsers modernos bloqueiam redirects de HTTPS para HTTP local em certas configurações
+
+### 1.2 Estado Atual do Código
+
+**`packages/cli/src/commands/login.ts`**
+- `waitForOAuthCallback()` (L92–L204): inicia servidor em `::` com fallback para `127.0.0.1`
+- `onListening` callback (L146–L173): captura apenas `address.port`, ignora `address.address`
+- URL de autenticação (L156–L157): envia apenas `port` e `state` ao web app — **sem `host`**
+
+```typescript
+// Linha 153–157 — estado atual (sem host)
+const port = address.port;
+const authUrl =
+  `${WEB_APP_URL}/api/auth/cli-callback?port=${port}&state=${encodeURIComponent(expectedState)}`;
 ```
-Error: release-please failed: GitHub Actions is not permitted to create or approve pull requests.
+
+**`packages/web/src/app/api/auth/cli-callback/route.ts`**
+- Fast path (L47–L49): usa `localhost` hardcoded na URL de callback
+- Não lê nem valida nenhum parâmetro `host`
+- Não salva cookie `aitk-cli-host`
+
+```typescript
+// Linha 47 — estado atual (localhost hardcoded)
+const callbackUrl = `http://localhost:${port}/callback`
+  + `?token=...&state=...`;
 ```
 
-### 1.2 Análise do Código Existente
+**`packages/web/src/app/api/auth/callback/route.ts`**
+- Fluxo CLI (L91–L92): usa `localhost` hardcoded na URL de callback
+- Não lê cookie `aitk-cli-host`
+- Limpa apenas `aitk-cli-port` e `aitk-cli-state` após uso
 
-**Arquivo:** `.github/workflows/release-please.yml`
-
-O workflow está estruturalmente correto:
-- Declara `permissions: pull-requests: write` e `contents: write` no nível do workflow (linha 10–13)
-- Usa `googleapis/release-please-action@v4` com `config-file` e `manifest-file` para monorepo (linhas 19–25)
-- Autentica via `${{ secrets.GITHUB_TOKEN }}` (linha 25)
-
-**Causa raiz:** O `GITHUB_TOKEN` tem suas permissões efetivas limitadas pela configuração do repositório em:
-
-> `Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"`
-
-Quando essa opção está desabilitada, o `GITHUB_TOKEN` **não pode criar PRs**, independentemente das permissões declaradas no YAML. As permissões declaradas no YAML são um teto superior — a configuração do repositório é o limitador real.
-
-### 1.3 Escopo de Impacto
-
-Apenas o workflow `release-please.yml` é afetado. Os workflows `ci.yml`, `publish.yml` e `npm-publish.yml` não utilizam criação de PRs e não são impactados.
+```typescript
+// Linha 91 — estado atual (localhost hardcoded)
+const callbackUrl = `http://localhost:${cliPort}/callback?token=...&state=...`;
+```
 
 ---
 
 ## 2. Abordagem Técnica
 
-### 2.1 Solução Primária — Configuração do Repositório (sem alteração de código)
+### 2.1 Solução Escolhida — Parâmetro `host` propagado via URL + cookie
 
-**Ação:** Habilitar a opção "Allow GitHub Actions to create and approve pull requests" no repositório GitHub.
-
-```
-GitHub → Repositório → Settings → Actions → General → Workflow permissions
-☑ Allow GitHub Actions to create and approve pull requests
-```
-
-Essa abordagem não requer nenhuma alteração em arquivos do repositório. O workflow já está corretamente configurado com as permissões YAML adequadas.
+O CLI detecta o endereço IP real de escuta após o bind do servidor e o envia ao web app como parâmetro `host`. O web app valida o host contra uma allowlist (`127.0.0.1`, `::1`), salva em cookie seguro `aitk-cli-host`, e o usa para construir a URL de callback correta.
 
 **Justificativa:**
-- Solução mais simples: zero mudanças de código.
-- Não cria dependências externas (sem PAT, sem secrets adicionais).
-- Não requer manutenção contínua (PATs expiram).
-- O workflow já possui as declarações de permissão corretas — basta remover o bloqueio no nível do repositório.
+- Resolve a causa raiz: a URL de callback usará o IP exato que o servidor está escutando
+- Seguro: allowlist estrita previne SSRF; o mecanismo `state` para CSRF permanece intacto
+- Mínimo impacto: apenas 3 arquivos modificados, sem novas dependências
+- Compatível com todos os SOs (Node.js `server.address()` retorna o IP real em todos os casos)
 
-### 2.2 Solução Alternativa — PAT (Personal Access Token)
+### 2.2 Alternativas Descartadas
 
-**Quando usar:** Quando não for possível alterar as configurações do repositório (ex: restrição de organização, política corporativa).
+| Alternativa | Razão da rejeição |
+|---|---|
+| Tentar `127.0.0.1` e `::1` sequencialmente no web app | Acrescenta latência, lógica complexa e não elimina ambiguidade |
+| CLI escutar em `127.0.0.1` sempre (remover dual-stack) | Quebra IPv6-only environments; não resolve Caso C |
+| Usar `localhost` com fallback automático de resolução DNS | Depende do comportamento do browser/OS, não controlável pelo app |
+| Deep link via custom URI scheme (`aitk://callback/...`) | Requer registro de protocolo no OS; não compatível com todos os ambientes |
 
-**Ações necessárias:**
+---
 
-1. Criar um PAT com escopo `repo` na conta do proprietário do repositório.
-2. Armazenar o PAT como secret `RELEASE_PLEASE_TOKEN` no repositório:
-   `Settings → Secrets and variables → Actions → New repository secret`
-3. Alterar `release-please.yml` para usar o novo secret:
+## 3. Componentes e Arquivos Modificados
 
-```yaml
-# Linha 25 — substituir:
-token: ${{ secrets.GITHUB_TOKEN }}
+| Arquivo | Tipo de Mudança | Responsabilidade |
+|---|---|---|
+| `packages/cli/src/commands/login.ts` | Modificação | Capturar IP real de escuta; incluir `host` na authUrl |
+| `packages/web/src/app/api/auth/cli-callback/route.ts` | Modificação | Ler/validar `host`; salvar cookie `aitk-cli-host`; usá-lo no fast path |
+| `packages/web/src/app/api/auth/callback/route.ts` | Modificação | Ler cookie `aitk-cli-host`; usá-lo no fluxo OAuth; limpar cookie após uso |
 
-# Por:
-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+---
+
+## 4. Design Detalhado por Componente
+
+### 4.1 CLI — `packages/cli/src/commands/login.ts`
+
+**Mudança:** Na função `onListening`, após capturar `address.port`, também capturar `address.address` (o IP real de escuta) e incluí-lo como parâmetro `host` na `authUrl`.
+
+```typescript
+// Dentro de onListening():
+const port = address.port;
+const host = address.address; // ex: '::1' ou '127.0.0.1'
+
+const authUrl =
+  `${WEB_APP_URL}/api/auth/cli-callback`
+  + `?port=${port}`
+  + `&state=${encodeURIComponent(expectedState)}`
+  + `&host=${encodeURIComponent(host)}`;  // NOVO
 ```
 
-**Justificativa para ser alternativa (não preferida):**
-- Requer criação e manutenção de um PAT (rotação periódica).
-- PATs com escopo `repo` têm acesso mais amplo que o necessário.
-- Adiciona complexidade operacional desnecessária se a configuração do repositório puder ser alterada.
+**Observação sobre `address.address`:**
+- Se `server.listen(0, '::')` bem-sucedido: `address.address === '::'` — mas o IP efetivo de conexão depende do OS. Neste caso, devemos normalizar para `::1` (loopback IPv6)
+- Se fallback para `server.listen(0, '127.0.0.1')`: `address.address === '127.0.0.1'`
+
+**Lógica de normalização do host:**
+
+```typescript
+// Normalizar '::' para '::1' (loopback IPv6), manter outros valores
+const rawAddress = address.address;
+const host = rawAddress === '::' ? '::1' : rawAddress;
+```
+
+Essa normalização é necessária porque `::` significa "bind em todas as interfaces", mas o loopback IPv6 é `::1`. O browser precisa do endereço de destino concreto, não do wildcard.
+
+**Mensagem de timeout (CA-07):** Incluir sugestão de `aitk login --token` na mensagem de erro do timeout:
+
+```typescript
+reject(new Error(
+  `Tempo limite de ${OAUTH_TIMEOUT_MS / 1000}s excedido. ` +
+  `Tente novamente ou use: aitk login --token <token>`
+));
+```
 
 ---
 
-## 3. Componentes e Arquivos
+### 4.2 Web App — `packages/web/src/app/api/auth/cli-callback/route.ts`
 
-### 3.1 Solução Primária
+**Mudanças:**
 
-| Componente | Ação | Detalhe |
-|---|---|---|
-| GitHub Settings | Configuração manual | Habilitar "Allow GitHub Actions to create and approve pull requests" |
-| `.github/workflows/release-please.yml` | **Sem alteração** | Já está correto |
+1. **Validar parâmetro `host`** (allowlist SSRF: `127.0.0.1`, `::1`):
 
-### 3.2 Solução Alternativa (PAT)
+```typescript
+const ALLOWED_CLI_HOSTS = new Set(['127.0.0.1', '::1']);
 
-| Componente | Ação | Detalhe |
-|---|---|---|
-| GitHub Secrets | Criação manual | Adicionar secret `RELEASE_PLEASE_TOKEN` com PAT `repo` |
-| `.github/workflows/release-please.yml` | **Modificação mínima** | Substituir `secrets.GITHUB_TOKEN` por `secrets.RELEASE_PLEASE_TOKEN` na linha 25 |
+const hostRaw = searchParams.get('host') ?? '127.0.0.1'; // default retrocompatível
+if (!ALLOWED_CLI_HOSTS.has(hostRaw)) {
+  return NextResponse.json(
+    { error: 'Parametro host invalido. Deve ser 127.0.0.1 ou ::1.' },
+    { status: 400 },
+  );
+}
+```
+
+O default `127.0.0.1` garante retrocompatibilidade se um CLI antigo (sem parâmetro `host`) chamar o endpoint.
+
+2. **Fast path — usar `host` na URL de callback:**
+
+```typescript
+// Formatar host IPv6 com colchetes (RFC 2732)
+const hostFormatted = hostRaw.includes(':') ? `[${hostRaw}]` : hostRaw;
+const callbackUrl = `http://${hostFormatted}:${port}/callback`
+  + `?token=${encodeURIComponent(tokenResult.token)}`
+  + `&state=${encodeURIComponent(state)}`;
+```
+
+3. **Fluxo OAuth — salvar cookie `aitk-cli-host`:**
+
+```typescript
+response.cookies.set('aitk-cli-host', hostRaw, {
+  httpOnly: true,
+  sameSite: 'lax',
+  secure: true,
+  path: '/',
+  maxAge: 600,
+});
+```
 
 ---
 
-## 4. Decisões Técnicas
+### 4.3 Web App — `packages/web/src/app/api/auth/callback/route.ts`
 
-### DT-01: Preferir configuração de repositório ao invés de PAT
+**Mudanças:**
 
-**Decisão:** A solução primária é a configuração de settings do repositório.
+1. **Ler cookie `aitk-cli-host`** junto com `aitk-cli-port` e `aitk-cli-state`:
 
-**Alternativas consideradas:**
-1. **PAT** — funciona, mas adiciona overhead operacional (rotação, escopo mais amplo).
-2. **GitHub App personalizado** — excesso de complexidade para o problema em questão.
-3. **Alterar o workflow para usar `gh` CLI** — não resolve o bloqueio de permissão; o `GITHUB_TOKEN` ainda seria usado sob o capô.
+```typescript
+const cliPort = request.cookies.get('aitk-cli-port')?.value;
+const cliState = request.cookies.get('aitk-cli-state')?.value;
+const cliHost = request.cookies.get('aitk-cli-host')?.value ?? '127.0.0.1'; // default retrocompatível
+```
 
-**Conclusão:** A opção de settings é a menos invasiva e a mais alinhada com o princípio de mínima mudança.
+2. **Usar `cliHost` na URL de callback:**
 
-### DT-02: Não alterar outros workflows
+```typescript
+const hostFormatted = cliHost.includes(':') ? `[${cliHost}]` : cliHost;
+const callbackUrl = `http://${hostFormatted}:${cliPort}/callback`
+  + `?token=${encodeURIComponent(tokenResult.token)}`
+  + `&state=${encodeURIComponent(cliState)}`;
+```
 
-**Decisão:** `ci.yml`, `publish.yml` e `npm-publish.yml` não serão tocados.
+3. **Limpar cookie `aitk-cli-host` após uso:**
 
-**Justificativa:** O problema é exclusivo do `release-please.yml`. Alterar outros arquivos amplia o risco sem benefício.
-
-### DT-03: Manter permissões YAML no workflow
-
-**Decisão:** As declarações `contents: write` e `pull-requests: write` permanecem no YAML mesmo após a correção.
-
-**Justificativa:** Seguem o princípio do mínimo privilégio e documentam explicitamente as permissões requeridas pelo workflow, independente de qual token for usado.
+```typescript
+response.cookies.delete('aitk-cli-host');
+response.cookies.delete('aitk-cli-port');
+response.cookies.delete('aitk-cli-state');
+response.cookies.delete('aitk-auth-next');
+```
 
 ---
 
-## 5. Riscos e Trade-offs
+## 5. Modelos de Dados
+
+### 5.1 Novos Parâmetros de URL
+
+| Parâmetro | Origem | Destino | Valores Permitidos | Obrigatório |
+|---|---|---|---|---|
+| `host` | CLI → web app (`cli-callback`) | Query param da authUrl | `127.0.0.1`, `::1` | Não (default: `127.0.0.1`) |
+
+### 5.2 Novo Cookie
+
+| Nome | Valor | maxAge | Flags |
+|---|---|---|---|
+| `aitk-cli-host` | `127.0.0.1` ou `::1` | 600s | `httpOnly`, `secure`, `sameSite: lax` |
+
+As mesmas flags de segurança dos cookies existentes `aitk-cli-port` e `aitk-cli-state`.
+
+### 5.3 Formatação de IPv6 em URLs (RFC 2732)
+
+Endereços IPv6 em URLs devem ser envolvidos em colchetes:
+- `127.0.0.1` → `http://127.0.0.1:PORT/callback`
+- `::1` → `http://[::1]:PORT/callback`
+
+A lógica de formatação (`includes(':') ? '[host]' : host`) é aplicada nos dois endpoints do web app.
+
+---
+
+## 6. Decisões Técnicas
+
+### DT-01 — Allowlist no web app, não no CLI
+
+**Decisão:** A validação do host é feita no web app (servidor), não apenas no CLI.
+
+**Justificativa:** O web app é o responsável pelo redirect — ele deve validar independentemente qualquer input que influencie o destino de um redirect, mesmo que o CLI já envie apenas valores válidos. Defense in depth.
+
+### DT-02 — Default `127.0.0.1` para retrocompatibilidade
+
+**Decisão:** Se o parâmetro `host` não for enviado (CLI antigo), os endpoints usam `127.0.0.1` como default.
+
+**Justificativa:** Evita quebra total para CLIs que não foram atualizados. O comportamento é idêntico ao atual (antes do fix) para esses casos.
+
+### DT-03 — Normalizar `::` para `::1` no CLI
+
+**Decisão:** O CLI normaliza `address.address === '::'` para `::1` antes de enviar ao web app.
+
+**Justificativa:** `::` é o wildcard de bind (todas as interfaces), não é um endereço de destino válido para o browser. O loopback IPv6 correto é `::1`. A allowlist do web app aceita apenas `::1`, não `::`.
+
+### DT-04 — Formatação RFC 2732 aplicada no web app
+
+**Decisão:** A formatação `[::1]` é aplicada no web app ao construir a URL, não no CLI.
+
+**Justificativa:** O cookie e o parâmetro armazenam o IP puro (`::1`), sem colchetes. A formatação é responsabilidade de quem constrói a URL final — separar dados de apresentação.
+
+### DT-05 — Não alterar `generateCliToken` nem a tabela `api_tokens`
+
+**Decisão:** O mecanismo de geração e persistência de tokens permanece intocado.
+
+**Justificativa:** O bug é de roteamento de rede, não de geração de tokens. Tocar esses componentes ampliaria o risco sem benefício.
+
+---
+
+## 7. Riscos e Trade-offs
 
 | Risco | Probabilidade | Impacto | Mitigação |
 |---|---|---|---|
-| Configuração de repositório não pode ser alterada (política de organização) | Média | Alto | Adotar solução alternativa com PAT |
-| PAT expira e release-please para de funcionar | Alta (se PAT usado) | Alto | Documentar prazo de rotação; usar secret com alerta de expiração |
-| PAT com escopo `repo` concede acesso além do necessário | Alta (se PAT usado) | Médio | Usar Fine-grained PAT com permissões `contents: write` e `pull-requests: write` apenas |
-| Alteração de settings habilita criação de PRs por outros workflows não intencionais | Baixa | Baixo | Os outros workflows não têm `pull-requests: write` declarado, então o bloqueio padrão continua |
+| Browser bloqueia redirect de HTTPS para `http://[::1]:PORT` (Caso C) | Baixa | Alto | O fix resolve Casos A e B (root cause). Caso C é comportamento de browser e requer workaround documentado (ex.: `aitk login --token`) |
+| CLI antigo (sem `host`) chama web app novo | Média | Baixo | Default `127.0.0.1` garante comportamento retrocompatível |
+| `address.address` retorna valor inesperado | Muito baixa | Médio | Allowlist no web app rejeitará com HTTP 400; CLI exibirá erro claro |
+| Cookie `aitk-cli-host` não sendo enviado no fluxo OAuth (SameSite=lax cross-site redirect) | Baixa | Alto | `sameSite: lax` permite envio de cookies em navegações top-level GET, que é exatamente o caso aqui; padrão já usado pelos cookies existentes |
 
 ---
 
-## 6. Plano de Implementação
+## 8. Fluxo Corrigido
 
-### Opção A — Solução Primária (sem PR)
+### Fast Path (usuário com sessão ativa)
 
-1. Acessar `Settings → Actions → General` no repositório GitHub.
-2. Em "Workflow permissions", marcar "Allow GitHub Actions to create and approve pull requests".
-3. Salvar.
-4. Fazer um push de commit convencional na `main` e verificar se o job executa com sucesso.
+```
+CLI
+ ├─ server.listen(0, '::') → onListening
+ ├─ address = { port: PORT, address: '::' }
+ ├─ host = '::1'  ← normalização
+ └─ authUrl = /api/auth/cli-callback?port=PORT&state=STATE&host=%3A%3A1
 
-**Arquivos modificados no repositório:** nenhum.
+Browser → web app /api/auth/cli-callback
+ ├─ valida port ✓, state ✓, host='::1' ✓
+ ├─ usuário tem sessão ativa
+ ├─ gera CLI token
+ └─ redireciona para http://[::1]:PORT/callback?token=T&state=S
 
-### Opção B — Solução Alternativa (com PR)
+Browser → http://[::1]:PORT/callback  ← alcança o servidor CLI ✓
+ └─ CLI recebe token, exibe sucesso
+```
 
-1. Criar PAT (preferencialmente Fine-grained) com permissões:
-   - `contents: write`
-   - `pull-requests: write`
-2. Adicionar secret `RELEASE_PLEASE_TOKEN` no repositório.
-3. Editar `.github/workflows/release-please.yml`, linha 25:
-   - De: `token: ${{ secrets.GITHUB_TOKEN }}`
-   - Para: `token: ${{ secrets.RELEASE_PLEASE_TOKEN }}`
-4. Abrir PR com a alteração, fazer merge na `main`.
-5. Verificar execução do workflow.
+### Fluxo OAuth Completo (usuário sem sessão)
 
-**Arquivos modificados no repositório:** `.github/workflows/release-please.yml`
+```
+CLI → authUrl com host='::1'
+
+Browser → web app /api/auth/cli-callback
+ ├─ valida host ✓
+ ├─ sem sessão → redireciona para GitHub OAuth
+ └─ salva cookies: aitk-cli-port, aitk-cli-state, aitk-cli-host='::1'
+
+GitHub → web app /api/auth/callback
+ ├─ lê cookies: port, state, host='::1'
+ ├─ gera CLI token
+ ├─ redireciona para http://[::1]:PORT/callback?token=T&state=S  ← host correto ✓
+ └─ limpa cookies aitk-cli-*
+
+Browser → http://[::1]:PORT/callback ← alcança servidor CLI ✓
+ └─ CLI recebe token, exibe sucesso
+```
 
 ---
 
-## 7. Critérios de Verificação
+## 9. Critérios de Verificação Pós-Implementação
 
-Após a implementação, validar:
-
-- [ ] Job `release-please` executa sem erros na aba Actions.
-- [ ] PR de release é criado/atualizado pelo bot `github-actions[bot]`.
-- [ ] Logs não exibem `GitHub Actions is not permitted to create or approve pull requests`.
-- [ ] Workflows `ci.yml`, `publish.yml` e `npm-publish.yml` continuam funcionando.
-- [ ] Se PAT usado: nenhum valor literal de token no YAML (`grep -i token .github/workflows/release-please.yml` não retorna valor hardcoded).
+- [ ] `aitk login` com servidor em IPv4 (`127.0.0.1`): login completa em < 10s
+- [ ] `aitk login` com servidor em IPv6 (`::1`): login completa em < 10s
+- [ ] Host inválido (ex: `192.168.1.1`) retorna HTTP 400 em `/api/auth/cli-callback`
+- [ ] Fluxo OAuth completo (sem sessão) entrega token corretamente ao CLI
+- [ ] Cookie `aitk-cli-host` é criado e limpo após uso no fluxo OAuth
+- [ ] `aitk login --token aitk_xxx` funciona sem alteração de comportamento
+- [ ] Mensagem de timeout inclui sugestão de `aitk login --token <token>`

--- a/docs/specs/REQUIREMENTS.md
+++ b/docs/specs/REQUIREMENTS.md
@@ -1,99 +1,169 @@
-# Requisitos — Issue #5: Falha no Job de Release (release-please)
+# Requisitos — Issue #17: Erro no login do CLI via OAuth
 
 ## Resumo do Problema
 
-O workflow `Release Please` (`.github/workflows/release-please.yml`) falha ao tentar criar um Pull Request automático de release. O erro reportado é:
+O comando `aitk login` inicia um fluxo OAuth via browser para autenticação no AI Toolkit Registry. O browser abre corretamente, mas o CLI nunca recebe o callback de retorno, resultando em timeout de 120 segundos.
+
+### Fluxo atual (com bug)
 
 ```
-Error: release-please failed: GitHub Actions is not permitted to create or approve pull requests.
-https://docs.github.com/rest/pulls/pulls#create-a-pull-request
+CLI → abre browser → /api/auth/cli-callback?port=PORT&state=STATE
+                                  ↓
+                    (usuário já logado no portal)
+                                  ↓
+              web app gera CLI token e redireciona para:
+              http://localhost:PORT/callback?token=...&state=...
+                                  ↓
+                    ❌ browser não consegue alcançar o servidor local
+                                  ↓
+                    CLI aguarda 120s → timeout
 ```
 
 ### Causa Raiz
 
-O GitHub possui uma configuração de segurança no nível do repositório (e/ou organização) que controla se o `GITHUB_TOKEN` padrão do GitHub Actions pode criar ou aprovar Pull Requests. Por padrão, essa permissão pode estar desabilitada.
+O endpoint `/api/auth/cli-callback` redireciona o browser para `http://localhost:PORT/callback` (usando sempre `localhost` como hostname). O servidor HTTP local do CLI, porém, escuta em `::` (dual-stack IPv6+IPv4), com fallback automático para `127.0.0.1` se IPv6 não estiver disponível.
 
-O workflow **já declara** as permissões corretas no YAML:
+Há incompatibilidade de endereço em dois cenários:
 
-```yaml
-permissions:
-  contents: write
-  pull-requests: write
-```
+- **Caso A**: Servidor CLI escuta em `::` com `IPV6_V6ONLY=1` (kernel Linux com IPv6 exclusivo) → browser resolve `localhost` como `127.0.0.1` (IPv4) → conexão recusada
+- **Caso B**: Servidor CLI fez fallback para `127.0.0.1` (IPv4) → browser resolve `localhost` como `::1` (IPv6) → conexão recusada
+- **Caso C**: Políticas de segurança de alguns browsers bloqueiam redirect de HTTPS (`vercel.app`) para HTTP `localhost` em certas configurações
 
-Porém, as permissões declaradas no workflow só funcionam se a opção **"Allow GitHub Actions to create and approve pull requests"** estiver habilitada nas configurações do repositório em:
-
-> `Settings > Actions > General > Workflow permissions`
-
-Quando essa opção está desabilitada no nível do repositório/organização, o `GITHUB_TOKEN` é impedido de criar PRs, independentemente das permissões declaradas no workflow YAML.
+O mesmo problema ocorre no fluxo OAuth completo (usuário sem sessão ativa), pois `/api/auth/callback` também usa `http://localhost:${cliPort}/callback` no redirect final.
 
 ---
 
 ## Requisitos Funcionais
 
-### RF-01: Permissão para criar Pull Requests via GitHub Actions
-O sistema de CI/CD deve ser capaz de criar Pull Requests automaticamente na branch `main` usando o token de autenticação configurado no workflow `release-please.yml`.
+### RF-01 — Callback deve alcançar o servidor CLI
+O browser deve conseguir fazer requisição ao servidor HTTP temporário iniciado pelo CLI após completar o fluxo de autenticação no portal, independente de como `localhost` é resolvido no sistema do usuário.
 
-### RF-02: Execução bem-sucedida do Release Please
-O job `release-please` deve executar sem erros, criando ou atualizando o PR de release ao detectar commits convencionais (`feat`, `fix`, etc.) na branch `main`.
+### RF-02 — CLI deve informar o host real de escuta ao web app
+O CLI deve incluir o endereço IP real em que o servidor local está escutando (ex.: `127.0.0.1` ou `::1`) na URL de autenticação enviada ao web app, em vez de deixar o web app assumir `localhost`.
 
-### RF-03: Manutenção das permissões declaradas no workflow
-O arquivo `.github/workflows/release-please.yml` deve manter as declarações de permissão `contents: write` e `pull-requests: write` como boa prática de segurança (princípio do mínimo privilégio).
+### RF-03 — Web app deve usar o host informado pelo CLI na URL de callback
+Os endpoints `/api/auth/cli-callback` e `/api/auth/callback` devem construir a URL de callback usando o host informado pelo CLI (parâmetro `host`), não sempre `localhost`.
 
-### RF-04: Compatibilidade com o modo de autenticação adotado
-A solução deve funcionar com uma das seguintes abordagens, em ordem de preferência:
-1. **Habilitação da permissão no repositório** (configuração de settings): ativar "Allow GitHub Actions to create and approve pull requests" nas configurações do repositório GitHub.
-2. **PAT (Personal Access Token)**: substituir `${{ secrets.GITHUB_TOKEN }}` por um PAT com escopo `repo` armazenado como secret (ex: `secrets.RELEASE_PLEASE_TOKEN`), para os casos em que a configuração do repositório não puder ser alterada.
+### RF-04 — Web app deve validar o host informado pelo CLI
+O host recebido do CLI deve ser validado contra uma allowlist restrita (`127.0.0.1` e `::1`) para prevenir SSRF (Server-Side Request Forgery).
+
+### RF-05 — Compatibilidade com fast path (usuário já autenticado)
+Quando o usuário já possui sessão ativa no portal web, o CLI token deve ser gerado e entregue ao CLI sem exigir nova autenticação no GitHub/Supabase.
+
+### RF-06 — Compatibilidade com fluxo OAuth completo (usuário sem sessão)
+Quando o usuário não possui sessão ativa, o fluxo OAuth (GitHub → Supabase → callback) deve concluir com o CLI recebendo o token.
+
+### RF-07 — Cookie de host CLI deve ser preservado durante OAuth
+O host informado pelo CLI deve ser salvo em cookie seguro junto com `aitk-cli-port` e `aitk-cli-state`, para estar disponível no callback OAuth.
+
+### RF-08 — Mensagem de erro clara em caso de timeout
+Se o callback não for recebido dentro do prazo (120s), o CLI deve exibir mensagem de erro com sugestão de usar `aitk login --token <token>` como alternativa.
+
+### RF-09 — Fluxo `--token` não deve ser afetado
+O fluxo de autenticação via API token (`aitk login --token <token>`) não deve ser modificado.
 
 ---
 
 ## Requisitos Não-Funcionais
 
-### RNF-01: Segurança
-- O token utilizado deve ter o mínimo de escopos necessários.
-- Se for usado um PAT, ele deve ser rotacionado periodicamente e armazenado exclusivamente como GitHub Secret (nunca em código).
+### RNF-01 — Proteção CSRF preservada
+A correção não deve remover ou enfraquecer o mecanismo de validação via `state` (nonce CSRF).
 
-### RNF-02: Manutenibilidade
-- A solução deve ser simples e não introduzir dependências extras ou scripts adicionais.
-- A configuração deve ser auto-documentada via comentários no workflow YAML.
+### RNF-02 — Proteção SSRF no web app
+O web app deve validar o host recebido do CLI contra allowlist estrita (`127.0.0.1`, `::1`) antes de redirecionar, evitando SSRF.
 
-### RNF-03: Sem impacto em outros workflows
-- A correção não deve alterar o comportamento dos workflows `ci.yml`, `publish.yml` ou `npm-publish.yml`.
+### RNF-03 — Sem exposição de token
+O CLI token não deve ser exposto em logs do servidor ou em qualquer saída persistente além do terminal do usuário.
+
+### RNF-04 — Compatibilidade cross-platform
+A solução deve funcionar em macOS, Linux e Windows.
+
+### RNF-05 — Sem novas dependências de runtime
+A correção não deve introduzir novas dependências de runtime no pacote CLI ou web.
+
+### RNF-06 — Tempo de resposta
+O fluxo de login interativo deve completar em menos de 30 segundos em condições normais de rede.
 
 ---
 
 ## Escopo
 
 ### Incluído
-- Diagnóstico e documentação da causa raiz do erro no workflow `release-please.yml`.
-- Correção do workflow para habilitar a criação de PRs pelo GitHub Actions.
-- Instrução de configuração de repositório necessária (settings do GitHub) e/ou ajuste no arquivo YAML de workflow.
+
+- Ajuste no CLI (`login.ts`): detectar o endereço real de escuta após `server.listen()` e incluir o parâmetro `host` na URL de autenticação enviada ao web app
+- Ajuste no web app (`cli-callback/route.ts`): ler e validar o parâmetro `host`, salvar em cookie `aitk-cli-host`, usar o host na construção da URL de callback (fast path)
+- Ajuste no web app (`callback/route.ts`): ler o cookie `aitk-cli-host` e usá-lo na URL de callback do fluxo OAuth completo; limpar o cookie após uso
+- Validação SSRF no web app (allowlist: `127.0.0.1`, `::1`)
 
 ### Excluído
-- Alterações nos workflows `ci.yml`, `publish.yml` e `npm-publish.yml`.
-- Alterações em código-fonte dos pacotes (`packages/`).
-- Mudanças na lógica de versionamento ou nas configurações do `release-please-config.json` e `.release-please-manifest.json`.
-- Criação de novos secrets além do que for estritamente necessário para a correção.
+
+- Alteração no mecanismo de geração ou armazenamento de tokens (`generateCliToken`, tabela `api_tokens`)
+- Mudança no fluxo `--token` (CI/CD via API token)
+- Suporte a outros providers OAuth além do GitHub
+- Alteração na UI do portal web
+- Mudança no valor do timeout de 120s
+- Alteração em outros comandos CLI
 
 ---
 
 ## Critérios de Aceitação
 
-| # | Critério | Como verificar |
-|---|----------|---------------|
-| AC-01 | O workflow `Release Please` executa com sucesso após um commit convencional na branch `main` | Verificar o resultado do job na aba "Actions" do repositório GitHub — status deve ser ✅ `success` |
-| AC-02 | Um Pull Request de release é criado (ou atualizado) automaticamente pelo bot `github-actions[bot]` | Verificar a existência de um PR aberto com título no padrão `chore(main): release X.Y.Z` |
-| AC-03 | O erro `GitHub Actions is not permitted to create or approve pull requests` não aparece mais nos logs | Inspecionar logs do step `googleapis/release-please-action@v4` |
-| AC-04 | Nenhum outro workflow é quebrado pela alteração | Executar manualmente os workflows `CI`, `Publish Artifact` e `Publish to npm` e confirmar que todos passam |
-| AC-05 | Se for usado PAT, o token está armazenado como secret e não hardcoded no YAML | Inspecionar o arquivo `release-please.yml` — não deve conter nenhum valor literal de token |
+### CA-01 — Fast path com sessão ativa (IPv4)
+**Dado** que o usuário está autenticado no portal web e o servidor CLI escutou em `127.0.0.1`
+**Quando** executa `aitk login`
+**Então** o browser abre, o login completa em menos de 10s, e o CLI exibe mensagem de sucesso com nome do usuário.
+
+### CA-02 — Fast path com sessão ativa (IPv6)
+**Dado** que o usuário está autenticado no portal web e o servidor CLI escutou em `::1`
+**Quando** executa `aitk login`
+**Então** o browser abre, o login completa em menos de 10s, e o CLI exibe mensagem de sucesso com nome do usuário.
+
+### CA-03 — Fluxo OAuth sem sessão ativa
+**Dado** que o usuário não possui sessão ativa no portal
+**Quando** executa `aitk login`
+**Então** o browser abre o GitHub para autenticação, após autorizar o CLI exibe sucesso em menos de 30s.
+
+### CA-04 — Rejeição de host inválido (proteção SSRF)
+**Dado** que a requisição ao web app inclui um `host` diferente de `127.0.0.1` ou `::1`
+**Quando** o web app processa a requisição em `/api/auth/cli-callback`
+**Então** retorna HTTP 400 sem redirecionar.
+
+### CA-05 — Cookie de host preservado no fluxo OAuth
+**Dado** que o fluxo OAuth completo é executado (sem sessão ativa)
+**Quando** o callback do GitHub chega em `/api/auth/callback`
+**Então** o cookie `aitk-cli-host` está presente e é usado para construir a URL correta de retorno ao CLI.
+
+### CA-06 — Nenhuma regressão no fluxo `--token`
+**Quando** executa `aitk login --token aitk_xxx`
+**Então** o token é verificado e o login é concluído normalmente (comportamento inalterado).
+
+### CA-07 — Timeout com mensagem orientativa
+**Dado** que o callback não é recebido em 120s
+**Quando** o timeout expira
+**Então** o CLI exibe mensagem de erro que inclui sugestão de usar `aitk login --token <token>` como alternativa.
 
 ---
 
-## Decisões Técnicas Registradas
+## Contexto Técnico Relevante
 
-**Decisão:** A solução preferencial é habilitar "Allow GitHub Actions to create and approve pull requests" nas configurações do repositório (Settings > Actions > General), pois:
-- Não requer criação de secrets adicionais.
-- Não requer manutenção de um PAT.
-- O workflow já possui as permissões YAML corretas (`pull-requests: write`).
+| Componente | Arquivo | Responsabilidade |
+|---|---|---|
+| CLI — comando login | `packages/cli/src/commands/login.ts` | Inicia servidor local, abre browser, aguarda callback |
+| CLI — servidor HTTP local | `waitForOAuthCallback()` em `login.ts` (L92–L204) | Escuta em `::` com fallback para `127.0.0.1` |
+| Web — fast path | `packages/web/src/app/api/auth/cli-callback/route.ts` | Detecta sessão ativa e redireciona para CLI |
+| Web — OAuth callback | `packages/web/src/app/api/auth/callback/route.ts` | Conclui OAuth e redireciona para CLI |
+| Web — geração de token | `packages/web/src/lib/api/generate-cli-token.ts` | Gera e persiste CLI token no banco |
 
-**Alternativa (se settings não puder ser alterado):** Criar um PAT com escopo `repo`, armazená-lo como secret `RELEASE_PLEASE_TOKEN` e substituir `${{ secrets.GITHUB_TOKEN }}` no `token:` do workflow. Isso resolve o bloqueio mesmo sem alterar as configurações do repositório.
+**Parâmetros atuais enviados pelo CLI ao web app:**
+- `port`: porta aleatória escolhida pelo SO (parâmetro existente)
+- `state`: 256 bits de entropia, nonce CSRF (parâmetro existente)
+
+**Novo parâmetro proposto:**
+- `host`: endereço IP real em que o servidor está escutando (`127.0.0.1` ou `::1`)
+
+**Cookies CLI no web app (atuais):**
+- `aitk-cli-port`: porta do servidor CLI (maxAge: 600s, httpOnly, secure, sameSite: lax)
+- `aitk-cli-state`: nonce CSRF (mesmas flags)
+
+**Novo cookie proposto:**
+- `aitk-cli-host`: host real do servidor CLI (mesmas flags de segurança)

--- a/docs/specs/TASKS.md
+++ b/docs/specs/TASKS.md
@@ -1,36 +1,30 @@
-# Tarefas de Implementação — Issue #14: Login do CLI trava quando usuário já está autenticado na web
+# Tarefas de Implementação — Issue #17: Erro no login do CLI via OAuth
 
 > **Referências:** [REQUIREMENTS.md](./REQUIREMENTS.md) | [DESIGN.md](./DESIGN.md)
 >
-> **Estratégia adotada:** Modificar exclusivamente `packages/web/src/app/api/auth/cli-callback/route.ts` para detectar sessão Supabase existente e, se presente, gerar o CLI token diretamente e redirecionar para `localhost:{port}/callback` sem passar pelo fluxo OAuth completo. O CLI e o endpoint `/api/auth/callback` não serão alterados.
+> **Estratégia adotada:** Propagar o IP real de escuta do servidor CLI (`address.address`) ao web app via parâmetro `host`. O web app valida o host contra allowlist SSRF (`127.0.0.1`, `::1`), salva em cookie `aitk-cli-host`, e usa o host correto (com formatação RFC 2732 para IPv6) na URL de callback — eliminando a dependência de `localhost` hardcoded.
 
 ---
 
-## 1. Implementação da Detecção de Sessão em `cli-callback/route.ts`
+## 1. CLI — Detectar e propagar host real de escuta
 
-- [x] 1.1 Adicionar import de `generateCliToken` de `@/lib/api/generate-cli-token` em `packages/web/src/app/api/auth/cli-callback/route.ts`
-- [x] 1.2 Mover (ou duplicar antecipadamente) a instanciação de `supabase = createClient()` para logo após a validação de `port` e `state`, antes do bloco OAuth atual — `packages/web/src/app/api/auth/cli-callback/route.ts` linha 36
-- [x] 1.3 Adicionar chamada a `supabase.auth.getUser()` imediatamente após a instanciação do cliente Supabase, para verificar se há sessão ativa no browser do solicitante — `packages/web/src/app/api/auth/cli-callback/route.ts`
-- [x] 1.4 Implementar o caminho rápido (`if (user)`): chamar `generateCliToken(user.id)`, montar `callbackUrl = http://localhost:{port}/callback?token=...&state=...` e retornar `NextResponse.redirect(callbackUrl)` — `packages/web/src/app/api/auth/cli-callback/route.ts`
-- [x] 1.5 Adicionar tratamento de erro no caminho rápido: envolver `generateCliToken` em `try/catch` e retornar `NextResponse.json({ error: 'Falha ao gerar CLI token.' }, { status: 500 })` em caso de exceção — `packages/web/src/app/api/auth/cli-callback/route.ts`
-- [x] 1.6 Garantir que o bloco OAuth existente (linhas 37–70) permanece intacto e é executado apenas quando `user` é `null` ou `getUser()` retorna erro (caminho sem sessão) — `packages/web/src/app/api/auth/cli-callback/route.ts`
+- [x] 1.1 Em `packages/cli/src/commands/login.ts`, na função `onListening` (L146), capturar `address.address` e normalizar `'::'` para `'::1'` (loopback IPv6 concreto, necessário porque `::` é wildcard de bind, não endereço de destino)
+- [x] 1.2 Em `packages/cli/src/commands/login.ts`, incluir o parâmetro `&host=${encodeURIComponent(host)}` na `authUrl` construída em `onListening` (L156–L157)
+- [x] 1.3 Em `packages/cli/src/commands/login.ts`, atualizar a mensagem de erro do timeout (L193–L195) para incluir sugestão `aitk login --token <token>` como alternativa (CA-07)
 
-## 2. Verificação de Requisitos de Segurança e Integridade
+## 2. Web App — Endpoint fast path (`cli-callback/route.ts`)
 
-- [x] 2.1 Confirmar que o parâmetro `state` está incluído via `encodeURIComponent` no `callbackUrl` do caminho rápido, garantindo proteção CSRF (RF-03 / RNF-02) — `packages/web/src/app/api/auth/cli-callback/route.ts`
-- [x] 2.2 Confirmar que os cookies `aitk-cli-port` e `aitk-cli-state` **não são criados** no caminho rápido — o `response.cookies.set(...)` existente só deve ocorrer no ramo OAuth (DT-02) — `packages/web/src/app/api/auth/cli-callback/route.ts`
-- [x] 2.3 Confirmar que `supabase.auth.getUser()` é utilizado (e não `getSession()`) para validar a sessão com round-trip ao servidor Supabase, conforme DT-03 — `packages/web/src/app/api/auth/cli-callback/route.ts`
+- [x] 2.1 Em `packages/web/src/app/api/auth/cli-callback/route.ts`, ler o parâmetro `host` da query string, validá-lo contra allowlist `new Set(['127.0.0.1', '::1'])` com default retrocompatível `'127.0.0.1'`, e retornar HTTP 400 se o valor enviado não for válido (proteção SSRF — RF-04, RNF-02)
+- [x] 2.2 Em `packages/web/src/app/api/auth/cli-callback/route.ts`, substituir `localhost` hardcoded (L47) pelo `host` validado com formatação RFC 2732 para IPv6 (`host.includes(':') ? '[' + host + ']' : host`) na URL de callback do fast path (RF-03)
+- [x] 2.3 Em `packages/web/src/app/api/auth/cli-callback/route.ts`, salvar o cookie `aitk-cli-host` com as mesmas flags de segurança dos cookies existentes (`httpOnly`, `secure`, `sameSite: 'lax'`, `path: '/'`, `maxAge: 600`) no caminho OAuth — junto com `aitk-cli-port` e `aitk-cli-state` (RF-07)
 
-## 3. Validação Manual / Critérios de Aceitação
+## 3. Web App — Endpoint OAuth callback (`callback/route.ts`)
 
-- [ ] 3.1 Verificar CA-01: `aitk login` completa em menos de 5 segundos quando o browser possui sessão Supabase ativa (cookie válido) — sem interação do usuário no navegador
-- [ ] 3.2 Verificar CA-02: CLI recebe `token` e `state` válidos via query params no callback rápido; `token` é verificável via `GET /api/v1/auth/verify` e `state` é idêntico ao enviado pelo CLI
-- [ ] 3.3 Verificar CA-03: fluxo OAuth via GitHub ocorre normalmente quando o usuário **não** está autenticado na web — terminal conclui o login após autenticação no navegador
-- [ ] 3.4 Verificar CA-04: proteção CSRF é mantida em ambos os caminhos — CLI rejeita callback com `state` inválido ou ausente com erro explícito
-- [ ] 3.5 Verificar CA-05: login web normal (usuário acessando a página sem CLI, sem parâmetros `port`/`state`) não é afetado — `/api/auth/callback` continua funcionando sem cookies CLI presentes
-- [ ] 3.6 Verificar CA-06 (parcial): quando `generateCliToken` falha, o browser exibe mensagem de erro JSON `{ error: 'Falha ao gerar CLI token.' }` com HTTP 500 — comportamento esperado documentado no DESIGN.md seção 4.2
+- [x] 3.1 Em `packages/web/src/app/api/auth/callback/route.ts`, ler o cookie `aitk-cli-host` (L78–L79) junto com `aitk-cli-port` e `aitk-cli-state`; usar default `'127.0.0.1'` se ausente (retrocompatibilidade com CLI sem atualização — DT-02)
+- [x] 3.2 Em `packages/web/src/app/api/auth/callback/route.ts`, substituir `localhost` hardcoded (L91) pela variável `cliHost` com formatação RFC 2732 para IPv6 na URL de callback do fluxo OAuth completo (RF-06, DT-04)
+- [x] 3.3 Em `packages/web/src/app/api/auth/callback/route.ts`, incluir `response.cookies.delete('aitk-cli-host')` em todos os caminhos de saída do bloco CLI: sucesso (L96–L98) e erro (L106–L108)
 
 ---
 
 *Documento gerado automaticamente pelo pipeline SDD — Fase 3 (Tarefas).*
-*Issue: #14 | Branch: fix/issue-14 | Data: 2026-03-12*
+*Issue: #17 | Branch: fix/issue-17 | Data: 2026-03-12*

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -151,10 +151,13 @@ function waitForOAuthCallback(): Promise<CliCallbackResult> {
       }
 
       const port = address.port;
+      const rawAddress = address.address;
+      // Normalizar '::' (wildcard de bind) para '::1' (loopback IPv6 concreto)
+      const host = rawAddress === '::' ? '::1' : rawAddress;
 
       // Constrói URL para o web app (intermediário OAuth)
       const authUrl =
-        `${WEB_APP_URL}/api/auth/cli-callback?port=${port}&state=${encodeURIComponent(expectedState)}`;
+        `${WEB_APP_URL}/api/auth/cli-callback?port=${port}&state=${encodeURIComponent(expectedState)}&host=${encodeURIComponent(host)}`;
 
       logger.print(`  ${logger.stepIndicator(1, 3)} ${chalk.gray('Abrindo navegador para autenticacao via GitHub...')}`);
       logger.blank();
@@ -191,7 +194,7 @@ function waitForOAuthCallback(): Promise<CliCallbackResult> {
       if (!resolved) {
         server.close();
         reject(new Error(
-          `Tempo limite de ${OAUTH_TIMEOUT_MS / 1000}s excedido. Tente novamente.`,
+          `Tempo limite de ${OAUTH_TIMEOUT_MS / 1000}s excedido. Tente novamente ou use: aitk login --token <token>`,
         ));
       }
     }, OAUTH_TIMEOUT_MS);

--- a/packages/web/src/app/api/auth/callback/route.ts
+++ b/packages/web/src/app/api/auth/callback/route.ts
@@ -77,6 +77,7 @@ export async function GET(request: NextRequest) {
         // Verificar presença de cookies CLI para fluxo de login via terminal
         const cliPort = request.cookies.get('aitk-cli-port')?.value;
         const cliState = request.cookies.get('aitk-cli-state')?.value;
+        const cliHost = request.cookies.get('aitk-cli-host')?.value ?? '127.0.0.1'; // default retrocompatível
 
         if (cliPort && cliState) {
           console.log(`[auth/callback] Fluxo CLI detectado: port=${cliPort}`);
@@ -88,13 +89,16 @@ export async function GET(request: NextRequest) {
 
             const tokenResult = await generateCliToken(sessionUser.id);
 
-            const callbackUrl = `http://localhost:${cliPort}/callback?token=${encodeURIComponent(tokenResult.token)}&state=${encodeURIComponent(cliState)}`;
-            console.log(`[auth/callback] Redirecionando CLI para: http://localhost:${cliPort}/callback`);
+            // Formatar host IPv6 com colchetes (RFC 2732)
+            const hostFormatted = cliHost.includes(':') ? `[${cliHost}]` : cliHost;
+            const callbackUrl = `http://${hostFormatted}:${cliPort}/callback?token=${encodeURIComponent(tokenResult.token)}&state=${encodeURIComponent(cliState)}`;
+            console.log(`[auth/callback] Redirecionando CLI para: http://${hostFormatted}:${cliPort}/callback`);
 
             const response = NextResponse.redirect(callbackUrl);
             // Limpar cookies CLI após uso
             response.cookies.delete('aitk-cli-port');
             response.cookies.delete('aitk-cli-state');
+            response.cookies.delete('aitk-cli-host');
             response.cookies.delete('aitk-auth-next');
             return response;
           } catch (cliErr) {
@@ -105,6 +109,7 @@ export async function GET(request: NextRequest) {
             );
             response.cookies.delete('aitk-cli-port');
             response.cookies.delete('aitk-cli-state');
+            response.cookies.delete('aitk-cli-host');
             response.cookies.delete('aitk-auth-next');
             return response;
           }

--- a/packages/web/src/app/api/auth/cli-callback/route.ts
+++ b/packages/web/src/app/api/auth/cli-callback/route.ts
@@ -27,6 +27,16 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  // Validar parâmetro host (allowlist SSRF)
+  const ALLOWED_CLI_HOSTS = new Set(['127.0.0.1', '::1']);
+  const hostRaw = searchParams.get('host') ?? '127.0.0.1'; // default retrocompatível
+  if (!ALLOWED_CLI_HOSTS.has(hostRaw)) {
+    return NextResponse.json(
+      { error: 'Parametro host invalido. Deve ser 127.0.0.1 ou ::1.' },
+      { status: 400 },
+    );
+  }
+
   // Validar parâmetro state
   const state = searchParams.get('state') ?? '';
   if (state.length < 32) {
@@ -44,7 +54,9 @@ export async function GET(request: NextRequest) {
     // Caminho rápido: usuário já autenticado — gerar token CLI diretamente
     try {
       const tokenResult = await generateCliToken(user.id);
-      const callbackUrl = `http://localhost:${port}/callback`
+      // Formatar host IPv6 com colchetes (RFC 2732)
+      const hostFormatted = hostRaw.includes(':') ? `[${hostRaw}]` : hostRaw;
+      const callbackUrl = `http://${hostFormatted}:${port}/callback`
         + `?token=${encodeURIComponent(tokenResult.token)}`
         + `&state=${encodeURIComponent(state)}`;
       return NextResponse.redirect(callbackUrl);
@@ -84,6 +96,13 @@ export async function GET(request: NextRequest) {
     maxAge: 600,
   });
   response.cookies.set('aitk-cli-state', state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/',
+    maxAge: 600,
+  });
+  response.cookies.set('aitk-cli-host', hostRaw, {
     httpOnly: true,
     sameSite: 'lax',
     secure: true,


### PR DESCRIPTION
## Summary
- Corrige o processo de login do CLI propagando o host real de escuta ao web app via parâmetro `host`
- Resolve issue #17: O processo de login do CLI está com erro

## Test plan
- [ ] Verificar que o processo de login do CLI funciona corretamente
- [ ] Confirmar que o host real é propagado ao web app
- [ ] Testar em diferentes ambientes de rede

🤖 Generated with [Claude Code](https://claude.com/claude-code)