### PR TITLE
fix: issue #26 - Erro de versão ao usar o CLI

### DIFF
--- a/docs/specs/26-erro-de-versao-a-usar-o-cli/DESIGN.md
+++ b/docs/specs/26-erro-de-versao-a-usar-o-cli/DESIGN.md
@@ -1,0 +1,218 @@
+# Design Técnico — Issue #26: Erro de versão ao usar o CLI
+
+## 1. Contexto e Estado Atual
+
+### Estrutura do Monorepo
+
+O repositório é um monorepo Turborepo com três pacotes publicáveis:
+
+| Pacote | Nome npm | Versão | Público |
+|--------|----------|--------|---------|
+| `packages/shared` | `@tarcisiojunior/shared` | 0.2.3 | Sim |
+| `packages/cli` | `aitk-cli` | 0.2.8 | Sim |
+| `packages/web` | `@tarcisiojunior/web` | 0.3.5 | Não |
+
+`packages/cli/package.json` declara dependência exata:
+```json
+"@tarcisiojunior/shared": "0.2.3"
+```
+
+### Workflow Atual (`npm-publish.yml`)
+
+O workflow tem quatro jobs:
+
+```
+validate → publish-shared ┐
+                           ├→ summary
+validate → publish-cli    ┘
+```
+
+O `publish-shared` só roda se:
+- `package == 'all'` ou `package == 'shared'` (dispatch manual), **ou**
+- É um release com tag contendo `'shared'`
+
+O `publish-cli` roda com a condição:
+```yaml
+if: |
+  always() && needs.validate.result == 'success' && (
+    github.event.inputs.package == 'all' ||
+    github.event.inputs.package == 'cli' ||
+    (github.event_name == 'release' && contains(github.event.release.tag_name, 'cli'))
+  )
+```
+
+### Causa Raiz do Bug
+
+A função `always()` cancela a dependência implícita criada pelo `needs: [validate, publish-shared]`. Quando um release com tag contendo apenas `'cli'` foi disparado (ex.: `aitk-cli-v0.2.8`):
+
+1. `publish-shared` foi **skipped** (tag não continha `'shared'`)
+2. `publish-cli` rodou normalmente por causa do `always()`
+3. `aitk-cli@0.2.8` foi publicado **sem** que `@tarcisiojunior/shared@0.2.3` estivesse no registry
+
+---
+
+## 2. Abordagem Técnica
+
+A solução é composta de duas partes independentes:
+
+### Parte A — Correção Imediata (One-shot)
+
+Acionar manualmente o workflow `npm-publish.yml` com `package = shared` e `dry_run = false` para publicar `@tarcisiojunior/shared@0.2.3`. Isso restaura o funcionamento para usuários que já tentam instalar `aitk-cli@0.2.8`.
+
+Não há alteração de código nessa parte — é uma ação operacional de CI/CD.
+
+### Parte B — Correção Sistêmica (Workflow)
+
+Modificar `npm-publish.yml` em dois pontos:
+
+**B1. Remover `always()` da condição do `publish-cli`**
+
+Substitui a condição atual por uma que bloqueia o CLI quando `publish-shared` falhou (resultado `failure` ou `cancelled`). O resultado `skipped` continua aceitável (publicação seletiva é um caso de uso válido: ex.: publicar apenas o CLI quando o `shared` não mudou e já está disponível no registry).
+
+**B2. Adicionar step de validação da dependência no `publish-cli`**
+
+Antes de publicar o CLI, um step lê a versão de `@tarcisiojunior/shared` do `packages/cli/package.json` e verifica sua disponibilidade no registry via `npm view`. Se a versão não existir, o step falha com mensagem clara — impedindo a publicação e emitindo log observável (RNF-03).
+
+---
+
+## 3. Componentes e Arquivos Modificados
+
+### Único arquivo alterado
+
+| Arquivo | Tipo de mudança |
+|---------|-----------------|
+| `.github/workflows/npm-publish.yml` | Modificação |
+
+Nenhum arquivo de código-fonte, `package.json`, ou versão é alterado.
+
+### Mudanças detalhadas no workflow
+
+#### 3.1 Condição do `publish-cli` (linha 129)
+
+**Antes:**
+```yaml
+if: |
+  always() && needs.validate.result == 'success' && (
+    github.event.inputs.package == 'all' ||
+    github.event.inputs.package == 'cli' ||
+    (github.event_name == 'release' && contains(github.event.release.tag_name, 'cli'))
+  )
+```
+
+**Depois:**
+```yaml
+if: |
+  needs.validate.result == 'success' &&
+  (needs.publish-shared.result == 'success' || needs.publish-shared.result == 'skipped') && (
+    github.event.inputs.package == 'all' ||
+    github.event.inputs.package == 'cli' ||
+    (github.event_name == 'release' && contains(github.event.release.tag_name, 'cli'))
+  )
+```
+
+**Efeito:** Com `always()` removido, o comportamento padrão do GitHub Actions retorna — jobs com `needs` não rodam se uma dependência falhou ou foi cancelada. A condição explicitamente aceita `skipped` para suportar publicação seletiva (`package = cli`).
+
+#### 3.2 Novo step de validação no `publish-cli`
+
+Inserido **antes** do step "Verificar versão" do CLI, após o build:
+
+```yaml
+- name: Verificar disponibilidade de @tarcisiojunior/shared
+  working-directory: packages/cli
+  run: |
+    SHARED_VERSION=$(node -e "console.log(require('./package.json').dependencies['@tarcisiojunior/shared'])")
+    echo "🔍 Verificando @tarcisiojunior/shared@${SHARED_VERSION} no registry npm..."
+
+    if npm view "@tarcisiojunior/shared@${SHARED_VERSION}" version 2>/dev/null; then
+      echo "✅ @tarcisiojunior/shared@${SHARED_VERSION} disponível no registry."
+    else
+      echo "❌ @tarcisiojunior/shared@${SHARED_VERSION} NÃO encontrado no registry npm."
+      echo "   Publique o pacote shared antes de publicar o CLI."
+      exit 1
+    fi
+```
+
+---
+
+## 4. Modelos de Dados
+
+Não aplicável — a mudança é exclusivamente em configuração de CI/CD. Nenhum tipo, schema ou estrutura de dados é criado ou alterado.
+
+---
+
+## 5. Decisões Técnicas
+
+### D1 — Manter `skipped` como estado aceitável para `publish-shared`
+
+**Decisão:** `publish-cli` pode executar quando `publish-shared` foi `skipped`.
+
+**Alternativa considerada:** Bloquear o CLI sempre que `publish-shared` não for `success`.
+
+**Justificativa:** Bloquear no `skipped` impossibilitaria o caso de uso legítimo de publicar apenas o CLI (`package = cli`) quando o `shared` já existe no registry com a versão correta. O step de validação (B2) é a guarda real contra dependência ausente — ele consulta o registry independentemente de como o CI chegou até aquele ponto.
+
+---
+
+### D2 — Validação via `npm view` no step B2
+
+**Decisão:** Usar `npm view @tarcisiojunior/shared@<version> version` para verificar disponibilidade.
+
+**Alternativa considerada:** Tentar instalar com `npm install --dry-run`.
+
+**Justificativa:** `npm view` é uma consulta leve e direta ao registry sem efeitos colaterais. Retorna exit code não-zero quando a versão não existe. `npm install --dry-run` poderia ser confundido com a lógica de dry-run já existente no workflow e teria overhead maior.
+
+---
+
+### D3 — Não alterar versões dos pacotes
+
+**Decisão:** A correção publica `@tarcisiojunior/shared@0.2.3` exatamente como está no repositório.
+
+**Alternativa considerada:** Fazer bump de versão e republish do CLI.
+
+**Justificativa:** `aitk-cli@0.2.8` já está no registry e referencia `0.2.3`. Alterar versões quebraria a invariante que `aitk-cli@0.2.8` já estabelece para usuários. Publicar `shared@0.2.3` é a única mudança que restaura o contrato existente sem criar novas versões desnecessárias.
+
+---
+
+## 6. Riscos e Trade-offs
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|--------------|---------|-----------|
+| `npm view` pode ter falso positivo (versão existe mas corrompida) | Muito baixa | Médio | Fora do escopo; publicação com `--provenance` garante integridade |
+| Publicação manual do `shared` pode falhar por token expirado ou permissão | Baixa | Alto | Verificar segredo `NPM_TOKEN` antes de acionar o workflow |
+| A condição revisada pode introduzir regressão em outros gatilhos do workflow | Baixa | Médio | A condição foi analisada para todos os três gatilhos: `workflow_dispatch` com `all`/`shared`/`cli` e `release` com tags. Ver tabela abaixo. |
+
+### Tabela de compatibilidade da nova condição
+
+| Gatilho | `publish-shared` result | `publish-cli` executa? | Correto? |
+|---------|------------------------|------------------------|----------|
+| `package=all` | `success` | Sim | ✅ |
+| `package=all` | `skipped` (versão já existe) | Sim | ✅ (B2 valida) |
+| `package=shared` | `success` | Não (condição de pacote) | ✅ |
+| `package=cli` | `skipped` (não selecionado) | Sim | ✅ (B2 valida) |
+| release tag `shared-v*` | `success` | Não (tag não contém `cli`) | ✅ |
+| release tag `cli-v*` | `skipped` | Sim | ✅ (B2 valida) |
+| release tag `shared-v*` e falha | `failure` | Não | ✅ (bloqueado) |
+
+---
+
+## 7. Plano de Implementação
+
+### Passo 1 — Publicar `@tarcisiojunior/shared@0.2.3` (correção imediata)
+
+Acionar manualmente o workflow `npm-publish.yml` via GitHub Actions UI:
+- `package`: `shared`
+- `dry_run`: `false`
+
+Verificar após execução: `npm view @tarcisiojunior/shared@0.2.3 version`
+
+### Passo 2 — Corrigir o workflow (prevenção de reincidência)
+
+Editar `.github/workflows/npm-publish.yml`:
+1. Substituir a condição `if` do job `publish-cli` (remove `always()`, adiciona checagem explícita de `publish-shared.result`)
+2. Inserir step de validação da dependência antes do step "Verificar versão" no job `publish-cli`
+
+### Passo 3 — Verificar critérios de aceitação
+
+- CA-01: `npx aitk-cli help` sem erros
+- CA-02: `npm view @tarcisiojunior/shared@0.2.3 version` retorna `0.2.3`
+- CA-03/CA-04: Inspecionar lógica do workflow modificado (revisão de código)
+- CA-05: Executar o workflow com `dry_run=true` e verificar logs do step de validação

--- a/docs/specs/26-erro-de-versao-a-usar-o-cli/MANUAL_STEPS.md
+++ b/docs/specs/26-erro-de-versao-a-usar-o-cli/MANUAL_STEPS.md
@@ -1,0 +1,24 @@
+# Ações Manuais — Issue #26: Erro de versão ao usar o CLI
+
+## Publicação do @tarcisiojunior/shared@0.2.3 (Correção Imediata)
+
+- [ ] Acionar manualmente o workflow `npm-publish.yml` no GitHub Actions com os parâmetros:
+  - `package`: `shared`
+  - `dry_run`: `false`
+  - URL: https://github.com/tarcisiojr/ai-toolkit/actions/workflows/npm-publish.yml
+
+- [ ] Verificar que a publicação foi bem-sucedida:
+  ```bash
+  npm view @tarcisiojunior/shared@0.2.3 version
+  # Deve retornar: 0.2.3
+  ```
+
+- [ ] Validar que o CLI funciona em ambiente limpo:
+  ```bash
+  npx --yes aitk-cli help
+  # Deve executar sem erros de dependência ausente
+  ```
+
+## CI/CD — Validação do Workflow Corrigido
+
+- [ ] Após o merge do PR, executar o workflow `npm-publish.yml` com `dry_run=true` e `package=cli` para validar que o step "Verificar disponibilidade de @tarcisiojunior/shared" exibe a versão esperada e conclui com sucesso (CA-05)

--- a/docs/specs/26-erro-de-versao-a-usar-o-cli/REQUIREMENTS.md
+++ b/docs/specs/26-erro-de-versao-a-usar-o-cli/REQUIREMENTS.md
@@ -1,0 +1,118 @@
+# Requisitos — Issue #26: Erro de versão ao usar o CLI
+
+## Resumo do Problema
+
+Ao executar `npx aitk-cli help`, o npm falha com o erro:
+
+```
+npm error code ETARGET
+npm error notarget No matching version found for @tarcisiojunior/shared@0.2.3.
+```
+
+**Causa raiz**: `aitk-cli@0.2.8` foi publicado no npm com dependência em `@tarcisiojunior/shared@0.2.3`, porém essa versão do pacote `shared` não estava disponível no registry npm no momento da instalação. O pacote `shared` precisa ser publicado **antes** ou **junto** com o `cli` que o referencia.
+
+### Contexto Técnico
+
+O repositório é um monorepo gerenciado com Turborepo contendo três pacotes:
+
+| Pacote | Nome npm | Versão atual |
+|--------|----------|--------------|
+| `packages/shared` | `@tarcisiojunior/shared` | 0.2.3 |
+| `packages/cli` | `aitk-cli` | 0.2.8 |
+| `packages/web` | `@tarcisiojunior/web` (privado) | 0.3.5 |
+
+O `packages/cli/package.json` declara:
+```json
+"dependencies": {
+  "@tarcisiojunior/shared": "0.2.3"
+}
+```
+
+O workflow `npm-publish.yml` publica os pacotes separadamente, com `publish-cli` dependendo de `publish-shared` via `needs`. Porém, a condição `if` para `publish-cli` inclui `always()`, o que permite que o CLI seja publicado mesmo se a publicação do `shared` tiver sido pulada (ex.: versão já existente no npm). Se `shared` nunca foi publicado com a versão `0.2.3`, qualquer usuário que tente instalar `aitk-cli@0.2.8` vai falhar.
+
+---
+
+## Requisitos Funcionais
+
+### RF-01 — Garantir publicação ordenada: shared antes do cli
+
+O pacote `@tarcisiojunior/shared` **deve** ser publicado no npm com a versão correta **antes** que `aitk-cli` que o referencia seja publicado.
+
+**Critério**: Se `@tarcisiojunior/shared@X.Y.Z` não existir no registry npm, a publicação de qualquer versão de `aitk-cli` que dependa de `X.Y.Z` **deve** falhar com erro explícito, impedindo a publicação do CLI.
+
+---
+
+### RF-02 — Verificar disponibilidade da dependência antes de publicar o CLI
+
+O workflow de publicação do `aitk-cli` **deve** verificar que `@tarcisiojunior/shared` na versão exigida pelo `package.json` do CLI está disponível no registry npm antes de publicar.
+
+**Critério**: Um step de validação deve executar `npm view @tarcisiojunior/shared@<versão> version` e falhar o job se a versão não existir.
+
+---
+
+### RF-03 — Publicar a versão ausente do @tarcisiojunior/shared
+
+A versão `@tarcisiojunior/shared@0.2.3` **deve** ser publicada no npm para restaurar o funcionamento do `aitk-cli@0.2.8` já publicado.
+
+**Critério**: Após a correção, `npx aitk-cli help` deve executar sem erros de dependência ausente.
+
+---
+
+### RF-04 — Correção da lógica de dependência no workflow de publicação
+
+O job `publish-cli` no workflow `npm-publish.yml` **não deve** executar se `publish-shared` falhou ou foi cancelado (apenas "skipped" por não ter sido selecionado é aceitável).
+
+**Critério**: A condição `always()` no `publish-cli` deve ser substituída por uma verificação que bloqueie a publicação do CLI quando `publish-shared` falhou.
+
+---
+
+## Requisitos Não-Funcionais
+
+### RNF-01 — Idempotência
+
+A correção da publicação do `shared` não deve causar republicação de versões já existentes. O check de versão existente já presente no workflow (`npm view ... version`) deve ser mantido.
+
+### RNF-02 — Sem breaking changes
+
+A correção não deve alterar as APIs públicas do `shared` nem do `cli`, pois isso afetaria usuários já instalados.
+
+### RNF-03 — Observabilidade
+
+O workflow de publicação deve gerar logs claros indicando qual versão de `shared` era esperada e se ela estava disponível antes de tentar publicar o CLI.
+
+---
+
+## Escopo
+
+### Incluído
+
+- Publicação da versão `@tarcisiojunior/shared@0.2.3` no npm (correção imediata)
+- Ajuste no workflow `npm-publish.yml` para garantir ordenação e dependência correta entre publicações
+- Adição de step de validação de disponibilidade da dependência antes da publicação do CLI
+
+### Excluído
+
+- Mudanças nas versões dos pacotes (sem bump de versão neste fix)
+- Alterações nas APIs ou funcionalidades do `shared` ou `cli`
+- Modificações nos workflows `publish.yml`, `release-please.yml` ou `ci.yml`
+- Mudanças no pacote `web`
+
+---
+
+## Critérios de Aceitação
+
+| ID | Critério | Como verificar |
+|----|----------|----------------|
+| CA-01 | `npx aitk-cli help` executa sem erros em um ambiente limpo | Executar em máquina sem cache do aitk-cli instalado |
+| CA-02 | `npm view @tarcisiojunior/shared@0.2.3 version` retorna `0.2.3` | Rodar o comando diretamente |
+| CA-03 | O workflow `npm-publish.yml` falha se tentar publicar o CLI sem o `shared` disponível | Simular cenário com dry-run e versão de shared inexistente |
+| CA-04 | O job `publish-cli` não executa quando `publish-shared` falha | Verificar lógica da condição `if` no workflow |
+| CA-05 | O workflow de publicação emite log indicando a versão de `shared` esperada e sua disponibilidade | Inspecionar logs de CI após execução |
+
+---
+
+## Decisões de Análise
+
+- **Causa imediata vs. sistêmica**: O erro reportado é causado por `@tarcisiojunior/shared@0.2.3` não estar no npm. Isso pode ter ocorrido porque o `shared` nunca foi publicado nessa versão, ou porque foi publicado após o `cli`. A solução deve tratar ambos os casos.
+- **Prioridade**: Publicar o `shared` ausente é a ação mais urgente para restaurar o funcionamento para usuários finais. A correção do workflow previne reincidência.
+- **Sem alteração de versão**: Como `aitk-cli@0.2.8` já está publicado e referencia `@tarcisiojunior/shared@0.2.3`, a solução é publicar exatamente essa versão do `shared` — não uma nova versão.

--- a/docs/specs/26-erro-de-versao-a-usar-o-cli/TASKS.md
+++ b/docs/specs/26-erro-de-versao-a-usar-o-cli/TASKS.md
@@ -1,0 +1,17 @@
+# Tarefas — Issue #26: Erro de versão ao usar o CLI
+
+## 1. Correção Imediata — Publicar @tarcisiojunior/shared@0.2.3
+
+- [ ] 1.1 Acionar manualmente o workflow `npm-publish.yml` via GitHub Actions com `package=shared` e `dry_run=false` para publicar `@tarcisiojunior/shared@0.2.3` no registry npm
+- [ ] 1.2 Verificar que a publicação foi bem-sucedida executando `npm view @tarcisiojunior/shared@0.2.3 version` e confirmando retorno `0.2.3`
+- [ ] 1.3 Validar que `npx aitk-cli help` executa sem erros em ambiente limpo (sem cache do aitk-cli)
+
+## 2. Correção Sistêmica — Workflow npm-publish.yml
+
+- [x] 2.1 Remover `always()` da condição `if` do job `publish-cli` em `.github/workflows/npm-publish.yml` (linha 129), substituindo pela condição que aceita `publish-shared.result == 'success'` ou `publish-shared.result == 'skipped'` e bloqueia em caso de `failure` ou `cancelled`
+- [x] 2.2 Inserir step `Verificar disponibilidade de @tarcisiojunior/shared` no job `publish-cli` em `.github/workflows/npm-publish.yml`, posicionado antes do step `Verificar versão` (linha 155), que lê a versão requerida do `packages/cli/package.json` e valida sua existência no registry via `npm view`, falhando com mensagem clara se ausente
+
+## 3. Verificação e Validação
+
+- [x] 3.1 Revisar o workflow modificado confirmando que todos os cenários da tabela de compatibilidade (DESIGN.md §6) se comportam corretamente com a nova condição do `publish-cli`
+- [ ] 3.2 Executar o workflow `npm-publish.yml` com `dry_run=true` e `package=cli` e inspecionar os logs do step de validação para confirmar que a versão do `shared` é exibida e o resultado é observável (CA-05)


### PR DESCRIPTION
## Resumo

Corrige o erro de versão ao usar o CLI (#26), onde o pacote `@tarcisiojunior/shared` não estava publicado quando o CLI tentava ser publicado.

### Mudanças implementadas

- Adicionados arquivos de especificação e documentação do problema em `docs/specs/26-erro-de-versao-a-usar-o-cli/`
- **Nota:** A correção no workflow `.github/workflows/npm-publish.yml` está no commit `47ad8ce` na branch `fix/issue-26`, mas não pôde ser incluída neste PR devido a limitações de escopo do token (requer escopo `workflow`).

### Correção do Workflow (aplicar manualmente)

O commit `47ad8ce` na branch `fix/issue-26` contém a correção principal no workflow:

```diff
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -126,7 +126,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, publish-shared]
     if: |
-      always() && needs.validate.result == 'success' && (
+      needs.validate.result == 'success' &&
+      (needs.publish-shared.result == 'success' || needs.publish-shared.result == 'skipped') && (
         github.event.inputs.package == 'all' ||
         github.event.inputs.package == 'cli' ||
         (github.event_name == 'release' && contains(github.event.release.tag_name, 'cli'))
```

Além disso, adiciona um step que verifica disponibilidade de `@tarcisiojunior/shared` no registry npm antes de publicar o CLI.

## Ações manuais necessárias

- [ ] Aplicar a correção do workflow `npm-publish.yml` (commit `47ad8ce` na branch `fix/issue-26`) com um token que tenha escopo `workflow`
- [ ] Acionar manualmente o workflow `npm-publish.yml` para publicar `@tarcisiojunior/shared@0.2.3`
  - `package`: `shared`
  - `dry_run`: `false`
- [ ] Verificar que a publicação foi bem-sucedida: `npm view @tarcisiojunior/shared@0.2.3 version`
- [ ] Validar que o CLI funciona: `npx --yes aitk-cli help`
- [ ] Após o merge, executar o workflow `npm-publish.yml` com `dry_run=true` e `package=cli` para validar o step de verificação

Fixes #26