### PR TITLE
fix: Layout quebrando no mobile (#32)

### DIFF
--- a/docs/specs/32-layout-quebrando-no-mobile/DESIGN.md
+++ b/docs/specs/32-layout-quebrando-no-mobile/DESIGN.md
@@ -1,0 +1,189 @@
+# Design Técnico — Issue #32: Layout quebrando no mobile
+
+## 1. Contexto e Estado Atual do Código
+
+### Problema raiz
+
+A screenshot do issue mostra a tela de edição em um iPhone XS/11 (828×1792px) com o toolbar do `FileEditor` transbordando horizontalmente. A causa é o layout `flex items-center justify-between` com dois grupos de elementos side-by-side que não têm espaço suficiente em telas estreitas.
+
+### Componentes afetados e seus problemas
+
+| Componente | Arquivo | Linha(s) problemáticas | Problema |
+|---|---|---|---|
+| `FileEditor` | `packages/web/src/components/artifact/FileEditor.tsx` | 146–183 | Toolbar `flex justify-between` transborda em mobile; `max-h-[600px]` sem mínimo |
+| `FileBrowser` | `packages/web/src/components/artifact/FileBrowser.tsx` | 242–337 | `grid-cols-1 md:grid-cols-2` já está correto, mas `max-h-[500px]` fixo pode ser excessivo |
+| `MetadataEditor` | `packages/web/src/components/artifact/MetadataEditor.tsx` | 78, 193, 317 | `flex items-center justify-between` (label + botão "Editar") pode comprimir em telas estreitas |
+| `OwnerActions` | `packages/web/src/components/artifact/OwnerActions.tsx` | 35 | `flex items-center gap-3` pode ficar apertado no header — risco baixo dado que há apenas 1 botão + 1 span |
+
+### Análise detalhada do FileEditor (problema crítico)
+
+Estrutura atual do toolbar (linhas 146–183):
+```html
+<div class="flex items-center justify-between">         <!-- linha única rígida -->
+  <div class="flex items-center gap-3">
+    <span>{filePath}</span>                             <!-- texto longo variável -->
+    <div class="flex rounded border">                   <!-- botões Editor/Split/Preview -->
+      <button>Editor</button>
+      <button>Split</button>
+      <button>Preview</button>
+    </div>
+  </div>
+  <div class="flex items-center gap-2">
+    <button>Cancelar</button>
+    <button>Salvar como nova versão</button>            <!-- 21 chars -->
+  </div>
+</div>
+```
+
+Em 375px de largura, o texto do `filePath` + botões de modo + "Cancelar" + "Salvar como nova versão" somam mais do que a tela comporta, causando overflow horizontal.
+
+O editor e preview têm `max-h-[600px]` sem mínimo, o que em mobile ocupa toda a viewport disponível sem controle.
+
+---
+
+## 2. Abordagem Técnica Escolhida
+
+### Estratégia: `flex-wrap` com reordenação via `flex-col sm:flex-row`
+
+A abordagem escolhida é converter o toolbar de um `flex` em linha única para um layout que faz wrap em mobile e mantém a linha única no desktop. Isso é feito com:
+
+1. **Toolbar container**: `flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between`
+2. **Grupo de ações (cancelar/salvar)**: em mobile, alinhado à direita com `self-end sm:self-auto`
+3. **Modo Split**: oculto em mobile com `hidden sm:flex` dentro do grupo de botões de modo
+
+### Justificativa
+
+- **Sem JavaScript adicional**: usar só classes Tailwind evita adição de lógica condicional de viewport.
+- **Sem `useMediaQuery`**: window resize listeners ou hooks de media query adicionariam complexidade e custo de hidratação. O Tailwind CSS resolve isso em build time via classes responsivas.
+- **Preservação do tab-order**: o DOM permanece inalterado — apenas o layout visual muda via flexbox. Isso preserva a ordem de tabulação logicamente (RF-04/RNF-04).
+- **Zero regressão desktop**: as classes `sm:` só ativam em ≥ 640px; desktop fica idêntico.
+
+### Alternativas descartadas
+
+| Alternativa | Motivo de descarte |
+|---|---|
+| `useMediaQuery` hook + renderização condicional | Adiciona lógica JS/hidratação desnecessária; Tailwind já resolve no CSS |
+| CSS módulo customizado com `@media` | Viola RNF-01 (não introduzir CSS fora de classes Tailwind) |
+| Abreviar texto "Salvar como nova versão" | Mudança de cópia de UI — poderia ser feita como otimização opcional, mas não é a solução principal |
+| Remover completamente o modo Split em mobile via JS | `hidden sm:flex` no próprio botão é mais simples e idiomático |
+
+---
+
+## 3. Componentes e Arquivos a Modificar
+
+### 3.1 `FileEditor.tsx` — Prioridade: CRÍTICA
+
+**Localização**: `packages/web/src/components/artifact/FileEditor.tsx`
+
+**Mudanças no toolbar (linhas 146–183)**:
+
+```
+ANTES: <div className="mb-3 flex items-center justify-between">
+DEPOIS: <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+```
+
+**Grupo esquerdo (filePath + mode buttons)** — permanece igual exceto pelo botão Split:
+- Botão "Split" no grupo `['editor', 'split', 'preview']`: filtrar `split` em telas < sm **OU** aplicar `hidden sm:inline` apenas no botão Split.
+- Abordagem escolhida: condicional no map, renderizando o botão Split somente se não for mobile. Como não usaremos JS para detectar viewport, a solução CSS é: aplicar `hidden sm:inline-flex` (ou `sm:flex`) apenas ao botão Split dentro do grupo. O container do grupo de botões usa `flex`, então o botão com `hidden sm:flex` desaparece em mobile.
+
+**Grupo direito (cancelar/salvar)** — adicionar `self-end sm:self-auto`:
+```
+ANTES: <div className="flex items-center gap-2">
+DEPOIS: <div className="flex items-center gap-2 self-end sm:self-auto">
+```
+
+**Editor e preview (linhas 191, 197)** — ajustar altura máxima:
+```
+ANTES: className="max-h-[600px] overflow-auto ..."
+DEPOIS: className="max-h-[400px] sm:max-h-[600px] overflow-auto ..."
+```
+
+### 3.2 `FileBrowser.tsx` — Prioridade: BAIXA (verificação)
+
+**Localização**: `packages/web/src/components/artifact/FileBrowser.tsx`
+
+**Análise**: O grid `grid-cols-1 md:grid-cols-2` (linha 242) já está correto conforme RF-03/CA-04. Em mobile renderiza em coluna única automaticamente.
+
+**Ajuste menor**: a altura `max-h-[500px]` (linhas 244, 257) em mobile pode ser reduzida:
+```
+ANTES: className="max-h-[500px] overflow-y-auto ..."
+DEPOIS: className="max-h-[300px] sm:max-h-[500px] overflow-y-auto ..."
+```
+Isso evita que os dois painéis (árvore + visualização) juntos ocupem 1000px de scroll em mobile.
+
+### 3.3 `MetadataEditor.tsx` — Prioridade: BAIXA
+
+**Localização**: `packages/web/src/components/artifact/MetadataEditor.tsx`
+
+**Análise**: O `InlineEdit`, `TagEditor` e `CheckboxEditor` usam `flex items-center justify-between` com apenas dois elementos pequenos (label texto-xs e botão texto-[10px]). Em telas estreitas (375px), isso raramente transborda porque ambos são curtos. O `min-w-0` no label pode prevenir compressão extrema.
+
+**Mudança defensiva** no header de cada componente (linhas 78, 193, 317):
+```
+ANTES: <div className="flex items-center justify-between">
+DEPOIS: <div className="flex items-center justify-between gap-2 min-w-0">
+  <span className="... truncate">  <!-- adicionar truncate ao label -->
+```
+
+### 3.4 `OwnerActions.tsx` — Prioridade: MUITO BAIXA
+
+**Localização**: `packages/web/src/components/artifact/OwnerActions.tsx`
+
+**Análise**: O componente tem apenas um botão "+ Nova Versão" e um `<span>` "Última: vX.Y.Z". O `flex items-center gap-3` na linha 35 é simples e dificilmente causa overflow.
+
+**Mudança**: Nenhuma mudança necessária no próprio `OwnerActions.tsx`. O problema relatado nos requisitos provavelmente ocorre no componente pai que combina o header do artefato com `OwnerActions`. Se houver overflow, o pai deve aplicar `flex-wrap` no seu container, mas isso está fora do escopo (o `page.tsx` está excluído per REQUIREMENTS.md).
+
+---
+
+## 4. Modelos de Dados
+
+Não há alterações em modelos de dados, interfaces TypeScript ou APIs. As mudanças são exclusivamente de apresentação (classes CSS Tailwind).
+
+---
+
+## 5. Decisões Técnicas
+
+### DT-01: Não usar `useMediaQuery` hook
+
+**Decisão**: Usar classes Tailwind responsivas (`sm:`, `md:`) em vez de JavaScript para detecção de viewport.
+**Razão**: Mais simples, sem custo de hidratação, sem flash de conteúdo incorreto (FOUC), e compatível com SSR/RSC do Next.js.
+
+### DT-02: Ocultar botão Split via CSS (`hidden sm:flex`) em vez de lógica condicional
+
+**Decisão**: Aplicar `hidden sm:flex` no wrapper do botão Split dentro do grupo de modo.
+**Razão**: Mantém o DOM consistente entre server e client render, sem warnings de hidratação. O botão continua no DOM mas invisível em mobile — isso é aceitável para um botão de UI simples.
+
+### DT-03: `flex-col` no toolbar do FileEditor em vez de `flex-wrap`
+
+**Decisão**: Usar `flex-col gap-2 sm:flex-row` em vez de `flex-wrap` no container do toolbar.
+**Razão**: `flex-wrap` quebraria o layout de forma imprevisível dependendo do conteúdo do `filePath`. Com `flex-col sm:flex-row`, o comportamento em mobile é explícito e controlado: sempre duas linhas em mobile, sempre uma linha em desktop.
+
+### DT-04: Reduzir max-h no editor em mobile
+
+**Decisão**: `max-h-[400px] sm:max-h-[600px]` em vez de `max-h-[600px]` fixo.
+**Razão**: Em mobile com viewport de 812px de altura (iPhone XS), um editor de 600px mais o toolbar e o header do artefato ultrapassaria a viewport, forçando scroll de página desnecessário.
+
+---
+
+## 6. Riscos e Trade-offs
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|---|---|---|---|
+| Toolbar em duas linhas pode parecer "quebrado" visualmente | Baixa | Médio | Design de duas linhas é padrão em apps mobile — semanticamente correto |
+| Ocultar botão Split pode confundir usuários que alternam entre desktop e mobile | Baixa | Baixo | O modo ativo retorna a "editor" quando Split fica indisponível (comportamento a implementar: fallback de `viewMode`) |
+| `truncate` no label do MetadataEditor pode cortar textos importantes | Muito Baixa | Baixo | Labels são curtos e fixos no código ("Keywords", "Licença", etc.) |
+| Redução de `max-h-[500px]` para `max-h-[300px]` no FileBrowser pode ser insuficiente para árvores de arquivos grandes | Baixa | Baixo | A árvore tem scroll interno; 300px já acomoda ~15 itens visíveis |
+
+### Trade-off principal
+
+A abordagem CSS-only via Tailwind é mais simples e robusta que uma abordagem JS, mas significa que o botão Split permanece no DOM (apenas oculto). Se no futuro a lógica de `viewMode` precisar ser resetada ao entrar em mobile, seria necessário adicionar lógica JS (e.g., resetar `viewMode` para `editor` quando Split estava ativo e usuário rotaciona para mobile). Essa lógica adicional está fora do escopo desta issue — a solução atual previne o problema de UX mais crítico (overflow visual) sem introduzir complexidade desnecessária.
+
+---
+
+## 7. Resumo das Mudanças por Arquivo
+
+| Arquivo | Tipo de Mudança | Complexidade |
+|---|---|---|
+| `FileEditor.tsx` | Refatoração de classes Tailwind no toolbar + ajuste de max-h | Baixa |
+| `FileBrowser.tsx` | Ajuste de max-h com breakpoint sm | Muito Baixa |
+| `MetadataEditor.tsx` | Adicionar `min-w-0` e `truncate` nos headers inline | Muito Baixa |
+| `OwnerActions.tsx` | Nenhuma mudança necessária | — |

--- a/docs/specs/32-layout-quebrando-no-mobile/REQUIREMENTS.md
+++ b/docs/specs/32-layout-quebrando-no-mobile/REQUIREMENTS.md
@@ -1,0 +1,138 @@
+# Requisitos — Issue #32: Layout quebrando no mobile
+
+## Resumo do Problema
+
+Ao acessar a tela de edição no mobile (resolução ~828×1792px, equivalente a iPhone XS/11), o layout quebra de forma visível. Com base na análise do código, o problema principal está no componente `FileEditor` (`packages/web/src/components/artifact/FileEditor.tsx`), cujo toolbar usa `flex items-center justify-between` em uma única linha sem adaptação para telas estreitas.
+
+**Componentes afetados identificados:**
+
+| Componente | Arquivo | Problema |
+|---|---|---|
+| `FileEditor` | `src/components/artifact/FileEditor.tsx` | Toolbar (`flex justify-between`) transborda em mobile — path do arquivo + botões de modo + "Salvar como nova versão" não cabem em uma linha |
+| `FileBrowser` | `src/components/artifact/FileBrowser.tsx` | Grid `grid-cols-1 md:grid-cols-2` é responsivo, mas o painel de visualização pode ter scroll estranho em mobile |
+| `MetadataEditor` | `src/components/artifact/MetadataEditor.tsx` | Campos `InlineEdit` com `flex items-center justify-between` (label + botão "Editar") podem comprimir em telas estreitas |
+| `OwnerActions` | `src/components/artifact/OwnerActions.tsx` | `flex items-center gap-3` pode ser apertado em mobile quando combinado com o header do artefato |
+
+---
+
+## Requisitos Funcionais
+
+### RF-01 — Toolbar do FileEditor responsivo
+O toolbar do `FileEditor` deve reorganizar seus elementos para telas estreitas (< 640px):
+- O nome do arquivo e os botões de modo (Editor / Split / Preview) devem ocupar uma linha.
+- Os botões "Cancelar" e "Salvar como nova versão" devem ocupar uma segunda linha abaixo, alinhados à direita.
+- Em mobile, o modo "Split" não deve ser exibido (ou deve ser desabilitado), pois não faz sentido em telas estreitas.
+
+### RF-02 — Editor de código usável em mobile
+O editor CodeMirror embutido no `FileEditor` deve:
+- Ter altura adequada em telas mobile (não fixar `max-h-[600px]` sem um mínimo mínimo razoável).
+- Permitir scroll horizontal interno para linhas longas sem quebrar o layout da página.
+
+### RF-03 — FileBrowser com painel de visualização adaptado
+No `FileBrowser`, em mobile:
+- O layout deve ser em coluna única (`grid-cols-1`), com a árvore de arquivos acima e o painel de visualização abaixo (já implementado via `md:grid-cols-2`, confirmar que funciona corretamente).
+- A altura máxima dos painéis (`max-h-[500px]`) pode ser reduzida em mobile para evitar que ocupem a tela inteira.
+
+### RF-04 — MetadataEditor com campos inline responsivos
+Em cada campo do `MetadataEditor` (`InlineEdit`, `TagEditor`, `CheckboxEditor`):
+- O layout `flex items-center justify-between` (label + botão "Editar") deve funcionar corretamente em telas estreitas sem sobrescrever texto.
+
+### RF-05 — OwnerActions responsivo no header do artefato
+Os botões de `OwnerActions` dentro do header do artefato devem se adaptar corretamente em mobile, sem transbordar o card `flex items-start gap-4`.
+
+---
+
+## Requisitos Não-Funcionais
+
+### RNF-01 — Compatibilidade de breakpoints
+Usar os breakpoints padrão do Tailwind CSS já configurado no projeto:
+- `sm`: 640px
+- `md`: 768px
+- `lg`: 1024px
+
+Não introduzir CSS customizado fora de classes Tailwind (a menos que absolutamente necessário).
+
+### RNF-02 — Sem regressão desktop
+As correções mobile não devem alterar o comportamento ou aparência nas resoluções desktop (≥ 1024px).
+
+### RNF-03 — Performance
+Não adicionar dependências novas. As correções devem ser feitas apenas com classes Tailwind CSS existentes.
+
+### RNF-04 — Acessibilidade
+Botões que trocam de posição em mobile devem manter `tab-order` lógico e labels acessíveis.
+
+---
+
+## Escopo
+
+### Incluído
+- Correção de layout do `FileEditor` (toolbar + editor).
+- Verificação e ajuste do `FileBrowser` em mobile.
+- Correção de campos inline do `MetadataEditor` em telas estreitas.
+- Ajuste do `OwnerActions` dentro do header do artefato.
+
+### Excluído
+- Refatoração de lógica de negócio (save, upload, API calls).
+- Alterações nos componentes de servidor (`page.tsx`).
+- Suporte a gestos touch específicos (swipe, pinch-to-zoom no editor).
+- Alterações no `PublishPage` — a análise indicou que os grids `sm:grid-cols-5` e `sm:grid-cols-3` já são responsivos.
+- Criação de uma experiência de edição mobile nativa diferente da desktop.
+
+---
+
+## Critérios de Aceitação
+
+### CA-01 — FileEditor toolbar em mobile
+- **Dado** que o usuário acessa o `FileEditor` em um viewport de 375px ou 428px de largura
+- **Quando** o arquivo selecionado é de qualquer tipo (markdown ou não)
+- **Então** o toolbar deve exibir todos os botões sem overflow horizontal, com wrapping adequado
+
+### CA-02 — Botão "Salvar como nova versão" visível em mobile
+- **Dado** que o usuário está no `FileEditor` em mobile
+- **Quando** ele visualiza o toolbar
+- **Então** o botão "Salvar como nova versão" deve estar completamente visível e clicável, sem ser cortado pelo edge da tela
+
+### CA-03 — Modo Split desabilitado/oculto em mobile
+- **Dado** que o arquivo editado é Markdown
+- **Quando** o viewport é menor que 640px
+- **Então** o botão "Split" não deve ser exibido (ou deve estar desabilitado com tooltip explicativo)
+
+### CA-04 — FileBrowser layout single-column em mobile
+- **Dado** que o usuário acessa a página de artefato em um viewport < 768px
+- **Quando** há arquivos listados
+- **Então** a árvore de arquivos deve ocupar a largura total, e o painel de visualização deve aparecer abaixo (layout em coluna única)
+
+### CA-05 — MetadataEditor sem overflow em mobile
+- **Dado** que o usuário é dono do artefato e acessa a página em mobile
+- **Quando** visualiza os campos editáveis na sidebar
+- **Então** cada campo com label + botão "Editar" deve ser exibido sem overflow ou sobreposição de texto
+
+### CA-06 — Sem regressão em desktop
+- **Dado** que o usuário acessa qualquer tela de edição em viewport ≥ 1024px
+- **Quando** interage com os componentes
+- **Então** o layout deve ser idêntico ao estado anterior às correções (toolbar em linha única, split-view disponível para Markdown)
+
+### CA-07 — Teste visual em dispositivos reais
+- As correções devem ser validadas visualmente em, pelo menos:
+  - iPhone SE (375px)
+  - iPhone 12/13 (390px)
+  - Android médio (412px)
+  - Tablet pequeno (768px)
+
+---
+
+## Notas de Implementação
+
+> **Não implementar nada neste documento.** As notas abaixo são apenas para orientar a fase de implementação.
+
+- O problema mais crítico é o toolbar do `FileEditor` (linha 146-183 de `FileEditor.tsx`). A estrutura atual:
+  ```html
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-3"> <!-- path + mode buttons -->
+    <div class="flex items-center gap-2"> <!-- cancel + save buttons -->
+  ```
+  Deve ser adaptada com `flex-wrap` ou mudança para `flex-col` em `sm:flex-row`.
+
+- O texto "Salvar como nova versão" é longo (21 chars). Considerar abreviar para "Salvar versão" em mobile via `hidden sm:inline` / `sm:hidden`.
+
+- A classe `max-h-[600px]` no editor e preview em `FileEditor.tsx` linha 191 e 197 pode ser ajustada para `max-h-[400px] sm:max-h-[600px]` em mobile.

--- a/docs/specs/32-layout-quebrando-no-mobile/TASKS.md
+++ b/docs/specs/32-layout-quebrando-no-mobile/TASKS.md
@@ -1,0 +1,45 @@
+# Tarefas — Issue #32: Layout quebrando no mobile
+
+## 1. FileEditor — Toolbar Responsivo (Prioridade: CRÍTICA)
+
+- [x]1.1 Converter container do toolbar de `flex items-center justify-between` para `flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between` em `packages/web/src/components/artifact/FileEditor.tsx` (linha ~146)
+
+- [x]1.2 Ocultar o botão "Split" em mobile aplicando `hidden sm:flex` (ou `hidden sm:inline-flex`) no wrapper/elemento do botão Split dentro do grupo de modos em `packages/web/src/components/artifact/FileEditor.tsx` (linha ~155–165)
+
+- [x]1.3 Adicionar `self-end sm:self-auto` no grupo de botões de ação (Cancelar + Salvar) em `packages/web/src/components/artifact/FileEditor.tsx` para alinhar à direita em mobile (linha ~175–183)
+
+- [x]1.4 Ajustar altura máxima do editor CodeMirror de `max-h-[600px]` para `max-h-[400px] sm:max-h-[600px]` em `packages/web/src/components/artifact/FileEditor.tsx` (linha ~191)
+
+- [x]1.5 Ajustar altura máxima do painel de preview de `max-h-[600px]` para `max-h-[400px] sm:max-h-[600px]` em `packages/web/src/components/artifact/FileEditor.tsx` (linha ~197)
+
+---
+
+## 2. FileBrowser — Altura dos Painéis em Mobile (Prioridade: BAIXA)
+
+- [x]2.1 Reduzir altura máxima do painel da árvore de arquivos de `max-h-[500px]` para `max-h-[300px] sm:max-h-[500px]` em `packages/web/src/components/artifact/FileBrowser.tsx` (linha ~244)
+
+- [x]2.2 Reduzir altura máxima do painel de visualização de `max-h-[500px]` para `max-h-[300px] sm:max-h-[500px]` em `packages/web/src/components/artifact/FileBrowser.tsx` (linha ~257)
+
+---
+
+## 3. MetadataEditor — Campos Inline Responsivos (Prioridade: BAIXA)
+
+- [x]3.1 Adicionar `gap-2 min-w-0` ao container `flex items-center justify-between` do componente `InlineEdit` em `packages/web/src/components/artifact/MetadataEditor.tsx` (linha ~78)
+
+- [x]3.2 Adicionar classe `truncate` ao elemento de label dentro do `InlineEdit` para evitar overflow de texto em `packages/web/src/components/artifact/MetadataEditor.tsx` (linha ~78)
+
+- [x]3.3 Aplicar o mesmo ajuste (`gap-2 min-w-0` + `truncate` no label) no componente `TagEditor` em `packages/web/src/components/artifact/MetadataEditor.tsx` (linha ~193)
+
+- [x]3.4 Aplicar o mesmo ajuste (`gap-2 min-w-0` + `truncate` no label) no componente `CheckboxEditor` em `packages/web/src/components/artifact/MetadataEditor.tsx` (linha ~317)
+
+---
+
+## 4. Verificação e Validação
+
+- [x]4.1 Verificar no código que o grid do `FileBrowser` já usa `grid-cols-1 md:grid-cols-2` (coluna única em mobile) — nenhuma mudança necessária se confirmado; documentar resultado em comentário no PR
+
+- [x]4.2 Confirmar que `OwnerActions.tsx` não requer alterações (componente tem apenas um botão + um span, risco muito baixo de overflow)
+
+- [x]4.3 Revisar visualmente as mudanças do `FileEditor` com DevTools no breakpoint 375px (iPhone SE) e 428px (iPhone 12/13) para confirmar que o toolbar exibe em duas linhas sem overflow horizontal
+
+- [x]4.4 Revisar visualmente o layout desktop (≥ 1024px) para confirmar ausência de regressão: toolbar em linha única, botão Split visível para arquivos Markdown

--- a/packages/web/src/components/artifact/FileBrowser.tsx
+++ b/packages/web/src/components/artifact/FileBrowser.tsx
@@ -241,7 +241,7 @@ export default function FileBrowser({
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         {/* Árvore de arquivos */}
-        <div className="max-h-[500px] overflow-y-auto rounded-lg border border-white/[0.06] bg-white/[0.02] p-2">
+        <div className="max-h-[300px] sm:max-h-[500px] overflow-y-auto rounded-lg border border-white/[0.06] bg-white/[0.02] p-2">
           {tree.map((node) => (
             <TreeNodeComponent
               key={node.path}
@@ -254,7 +254,7 @@ export default function FileBrowser({
         </div>
 
         {/* Painel de visualização */}
-        <div className="max-h-[500px] overflow-y-auto rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+        <div className="max-h-[300px] sm:max-h-[500px] overflow-y-auto rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
           {!selectedFile ? (
             <p className="font-[family-name:var(--font-jetbrains)] text-sm text-[#64748b]">
               Selecione um arquivo para visualizar

--- a/packages/web/src/components/artifact/FileEditor.tsx
+++ b/packages/web/src/components/artifact/FileEditor.tsx
@@ -143,7 +143,7 @@ function FileEditorInner({ filePath, initialContent, onSave, onCancel }: FileEdi
   return (
     <div className="glass rounded-2xl p-4">
       {/* Toolbar */}
-      <div className="mb-3 flex items-center justify-between">
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <span className="font-[family-name:var(--font-jetbrains)] text-sm text-[#e2e8f0]">
             {filePath}
@@ -154,7 +154,7 @@ function FileEditorInner({ filePath, initialContent, onSave, onCancel }: FileEdi
                 <button
                   key={mode}
                   onClick={() => setViewMode(mode)}
-                  className={`px-2 py-0.5 font-[family-name:var(--font-jetbrains)] text-[10px] transition-colors ${
+                  className={`px-2 py-0.5 font-[family-name:var(--font-jetbrains)] text-[10px] transition-colors ${mode === 'split' ? 'hidden sm:inline-flex' : ''} ${
                     viewMode === mode
                       ? 'bg-[#00d4ff]/10 text-[#00d4ff]'
                       : 'text-[#64748b] hover:text-[#94a3b8]'
@@ -166,7 +166,7 @@ function FileEditorInner({ filePath, initialContent, onSave, onCancel }: FileEdi
             </div>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 self-end sm:self-auto">
           <button
             onClick={onCancel}
             className="rounded px-3 py-1 font-[family-name:var(--font-jetbrains)] text-xs text-[#94a3b8] hover:bg-white/[0.05]"
@@ -188,13 +188,13 @@ function FileEditorInner({ filePath, initialContent, onSave, onCancel }: FileEdi
         {viewMode !== 'preview' && (
           <div
             ref={editorRef}
-            className="max-h-[600px] overflow-auto rounded-lg border border-white/[0.06] bg-[#0a0a0f]"
+            className="max-h-[400px] sm:max-h-[600px] overflow-auto rounded-lg border border-white/[0.06] bg-[#0a0a0f]"
           />
         )}
 
         {/* Preview (Markdown) */}
         {isMarkdown && viewMode !== 'editor' && (
-          <div className="max-h-[600px] overflow-auto rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+          <div className="max-h-[400px] sm:max-h-[600px] overflow-auto rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
             <div
               className="prose prose-invert prose-sm max-w-none"
               dangerouslySetInnerHTML={{

--- a/packages/web/src/components/artifact/MetadataEditor.tsx
+++ b/packages/web/src/components/artifact/MetadataEditor.tsx
@@ -75,8 +75,8 @@ function InlineEdit({
 
   return (
     <div className={`rounded-lg border ${borderClass} bg-white/[0.02] px-3 py-2 transition-colors`}>
-      <div className="flex items-center justify-between">
-        <span className="font-[family-name:var(--font-jetbrains)] text-xs text-[#64748b]">
+      <div className="flex items-center justify-between gap-2 min-w-0">
+        <span className="truncate font-[family-name:var(--font-jetbrains)] text-xs text-[#64748b]">
           {label}
         </span>
         {isOwner && !editing && (
@@ -189,8 +189,8 @@ function TagEditor({
   if (!editing) {
     return (
       <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
-        <div className="flex items-center justify-between">
-          <span className="font-[family-name:var(--font-jetbrains)] text-xs text-[#64748b]">
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <span className="truncate font-[family-name:var(--font-jetbrains)] text-xs text-[#64748b]">
             {label}
           </span>
           {isOwner && (
@@ -313,8 +313,8 @@ function CheckboxEditor({
   if (!editing) {
     return (
       <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
-        <div className="flex items-center justify-between">
-          <span className="font-[family-name:var(--font-jetbrains)] text-xs text-[#64748b]">
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <span className="truncate font-[family-name:var(--font-jetbrains)] text-xs text-[#64748b]">
             {label}
           </span>
           {isOwner && (


### PR DESCRIPTION
## Resumo

Corrige o layout quebrando no mobile, conforme reportado na issue #32.

### Mudanças realizadas

- Corrigido o layout responsivo para dispositivos móveis
- Ajustes de CSS/estilos para garantir compatibilidade com telas pequenas

## Referência

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)